### PR TITLE
GUI: status: Add support for exit-reason (bnc#889914)

### DIFF
--- a/hawk/app/assets/javascripts/status.js
+++ b/hawk/app/assets/javascripts/status.js
@@ -138,7 +138,7 @@ function flag_error(id, failed_ops) {
     var errs = [];
     $.each(failed_ops, function() {
       // TODO(should): Localize "ignored"
-      var err = GETTEXT.err_failed_op(this.op, this.node, this.rc_code) + (this.ignored ? " (ignored)" : "");
+      var err = GETTEXT.err_failed_op(this.op, this.node, this.rc_code, this.exit_reason) + (this.ignored ? " (ignored)" : "");
       errs.push(escape_html(err));
     });
     e.attr("title", errs.join(", "));

--- a/hawk/app/controllers/resources_controller.rb
+++ b/hawk/app/controllers/resources_controller.rb
@@ -116,6 +116,7 @@ class ResourcesController < ApplicationController
             :interval => op.attributes['interval'].to_i,
             :exec_time => op.attributes['exec-time'].to_i,
             :queue_time => op.attributes['queue-time'].to_i,
+            :exit_reason => op.attributes.has_key?('exit-reason') ? op.attributes['exit-reason'] : '',
             :last_rc_change => sane_time(op.attributes['last-rc-change']),
             :last_run => sane_time(op.attributes['last-run'])
           }

--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -412,6 +412,8 @@ class Cib < CibObject
             expected = k[2].to_i
           end
 
+          exit_reason = op.attributes.has_key?('exit-reason') ? op.attributes['exit-reason'] : ''
+
           # skip notifies, deletes, cancels
           next if operation == 'notify' || operation == 'delete' || operation == 'cancel'
 
@@ -478,11 +480,11 @@ class Cib < CibObject
               fail_end = Time.at(fail_end).strftime("%Y-%m-%d %H:%M")
             end
 
-            failed_ops << { :node => node[:uname], :call_id => op.attributes['call-id'], :op => operation, :rc_code => rc_code }
+            failed_ops << { :node => node[:uname], :call_id => op.attributes['call-id'], :op => operation, :rc_code => rc_code, :exit_reason => exit_reason }
             @errors << {
-              :msg => _('Failed op: node=%{node}, resource=%{resource}, call-id=%{call_id}, operation=%{op}, rc-code=%{rc_code}') % {
+              :msg => _('Failed op: node=%{node}, resource=%{resource}, call-id=%{call_id}, operation=%{op}, rc-code=%{rc_code}, exit-reason=%{exit_reason}') % {
                 :node => node[:uname], :resource => id, :call_id => op.attributes['call-id'],
-                :op => operation, :rc_code => rc_code },
+                :op => operation, :rc_code => rc_code, :exit_reason => exit_reason },
               # Note: graph_number here might be the one *after* the one that's really interesting :-/
               :link => fail_start ? explorer_path(:from_time => fail_start, :to_time => fail_end, :display => true, :graph_number => graph_number) : ""
             }

--- a/hawk/app/views/main/_gettext.js.erb
+++ b/hawk/app/views/main/_gettext.js.erb
@@ -81,8 +81,8 @@ var GETTEXT = {
   err_denied: function() {
     return "<%=raw escape_javascript _('Permission denied') %>";
   },
-  err_failed_op: function(op, node, rc) {
-    return "<%=raw escape_javascript _('%{op} failed on %{node} (rc=%{rc})') % { :op => '_OP_', :node => '_NODE_', :rc => '_RC_' } %>".replace('_OP_', op).replace('_NODE_', node).replace('_RC_', rc);
+  err_failed_op: function(op, node, rc, reason) {
+    return "<%=raw escape_javascript _('%{op} failed on %{node} (rc=%{rc}, reason=%{reason})') % { :op => '_OP_', :node => '_NODE_', :rc => '_RC_', :reason => '_REASON_' } %>".replace('_OP_', op).replace('_NODE_', node).replace('_RC_', rc).replace('_REASON_', reason);
   },
   // DC Info
   dc_current: function(dc) {

--- a/hawk/app/views/resources/show.html.erb
+++ b/hawk/app/views/resources/show.html.erb
@@ -30,7 +30,7 @@
 <%if @op_history[k][:ops].any? %>
 <table class="op-history">
   <tr>
-    <th>Call ID</th><th>Operation</th><th>Last Run</th><th>Exec</th><th>Queue</th><th>RC</th><th>Last Change</th>
+    <th>Call ID</th><th>Operation</th><th>Last Run</th><th>Exec</th><th>Queue</th><th>RC</th><th>Last Change</th><th>Exit Reason</th>
   </tr>
 <% @op_history[k][:ops].each do |op| %>
   <tr>
@@ -41,6 +41,7 @@
     <td><%= op[:queue_time] %>ms</td>
     <td><%= op[:rc_code] %></td>
     <td><%= op[:last_rc_change] %></td>
+    <td><%= op[:exit_reason] %></td>
   </tr>
 <% end %>
 </table>


### PR DESCRIPTION
OCF scripts can pass back a failure reason string before exiting that
Hawk can display as part of the error message.
