### PR TITLE
Tools: Drop extraneous groups when becoming haclient in hawk_invoke

### DIFF
--- a/tools/hawk_invoke.c
+++ b/tools/hawk_invoke.c
@@ -67,6 +67,7 @@
 #include <string.h>
 #include <pwd.h>
 #include <grp.h>
+#include <errno.h>
 #include "common.h"
 
 struct cmd_map
@@ -198,6 +199,20 @@ int main(int argc, char **argv)
 	}
 	/* (bit rough to drop const...) */
 	argv[2] = (char *)cmd->path;
+
+	/*
+	 * Drop extraneous groups. Not doing this is a security issue.
+	 * See POS36-C.
+	 *
+	 * This will fail if we aren't root, so don't bother checking
+	 * the return value, this is just done as an optimistic privilege
+	 * dropping function.
+	 */
+	{
+		int save_errno = errno;
+		setgroups(0, NULL);
+		errno = save_errno;
+	}
 
 	/*
 	 * Become the new user.  Note that at this point, grp still refers


### PR DESCRIPTION
This should fix a potential security hole:

[    8s] hawk.x86_64: W: missing-call-to-setgroups-before-setuid /usr/sbin/hawk_invoke
[    8s] This executable is calling setuid and setgid without setgroups or initgroups.
[    8s] There is a high probability this mean it didn't relinquish all groups, and
[    8s] this would be a potential security issue to be fixed. Seek POS36-C on the web
[    8s] for details about the problem.
