### PR TITLE
Tags support (fate#318319)

### DIFF
--- a/hawk/app/assets/javascripts/application.js
+++ b/hawk/app/assets/javascripts/application.js
@@ -42,6 +42,7 @@
 //= require module/masters
 //= require module/clones
 //= require module/groups
+//= require module/tags
 //= require module/locations
 //= require module/colocations
 //= require module/orders

--- a/hawk/app/assets/javascripts/module/tags.js
+++ b/hawk/app/assets/javascripts/module/tags.js
@@ -1,0 +1,148 @@
+//======================================================================
+//                        HA Web Konsole (Hawk)
+// --------------------------------------------------------------------
+//            A web-based GUI for managing and monitoring the
+//          Pacemaker High-Availability cluster resource manager
+//
+// Copyright (c) 2009-2013 SUSE LLC, All Rights Reserved.
+//
+// Author: Tim Serong <tserong@suse.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of version 2 of the GNU General Public License as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it would be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// Further, this software is distributed without any warranty that it is
+// free of the rightful claim of any third person regarding infringement
+// or the like.  Any license provided herein, whether implied or
+// otherwise, applies only to this software file.  Patent licenses, if
+// any, provided herein do not apply to combinations of this program with
+// other software, or any other product whatsoever.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write the Free Software Foundation,
+// Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+//
+//======================================================================
+
+$(function() {
+  $('#tags #middle table.tags')
+    .bootstrapTable({
+      method: 'get',
+      url: Routes.cib_tags_path(
+        $('body').data('cib'),
+        { format: 'json' }
+      ),
+      striped: true,
+      pagination: true,
+      pageSize: 50,
+      pageList: [10, 25, 50, 100, 200],
+      sidePagination: 'client',
+      smartDisplay: false,
+      search: true,
+      searchAlign: 'left',
+      showColumns: true,
+      showRefresh: true,
+      minimumCountColumns: 0,
+      sortName: 'id',
+      sortOrder: 'asc',
+      columns: [{
+        field: 'id',
+        title: __('Tag ID'),
+        sortable: true,
+        switchable: false,
+        clickToSelect: true
+      }, {
+        field: 'operate',
+        title: __('Operations'),
+        sortable: false,
+        clickToSelect: false,
+        class: 'col-sm-2',
+        events: {
+          'click .delete': function (e, value, row, index) {
+            e.preventDefault();
+            var $self = $(this);
+
+            $.ajax({
+              dataType: 'json',
+              method: 'POST',
+              data: {
+                _method: 'delete'
+              },
+              url: Routes.cib_tag_path(
+                $('body').data('cib'),
+                row.id,
+                { format: 'json' }
+              ),
+
+              success: function(data) {
+                if (data.success) {
+                  $.growl({
+                    message: data.message
+                  },{
+                    type: 'success'
+                  });
+
+                  $self.parents('table').bootstrapTable('refresh')
+                } else {
+                  if (data.error) {
+                    $.growl({
+                      message: data.error
+                    },{
+                      type: 'danger'
+                    });
+                  }
+                }
+              },
+              error: function(xhr, status, msg) {
+                $.growl({
+                  message: xhr.responseJSON.error || msg
+                },{
+                  type: 'danger'
+                });
+              }
+            });
+          }
+        },
+        formatter: function(value, row, index) {
+          var operations = []
+
+          operations.push([
+            '<a href="',
+                Routes.edit_cib_tag_path(
+                  $('body').data('cib'),
+                  row.id
+                ),
+              '" class="edit btn btn-default btn-xs" title="',
+              __('Edit'),
+            '">',
+              '<i class="fa fa-pencil"></i>',
+            '</a> '
+          ].join(''));
+
+          operations.push([
+            '<a href="',
+                Routes.cib_tag_path(
+                  $('body').data('cib'),
+                  row.id
+                ),
+              '" class="delete btn btn-default btn-xs" title="',
+              __('Delete'),
+            '" data-confirm="' + i18n.translate('Are you sure you wish to delete %s?').fetch(row.id) + '">',
+              '<i class="fa fa-trash"></i>',
+            '</a> '
+          ].join(''));
+
+          return [
+            '<div class="btn-group" role="group">',
+              operations.join(''),
+            '</div>',
+          ].join('');
+        }
+      }]
+    });
+});

--- a/hawk/app/controllers/tags_controller.rb
+++ b/hawk/app/controllers/tags_controller.rb
@@ -1,0 +1,192 @@
+#======================================================================
+#                        HA Web Konsole (Hawk)
+# --------------------------------------------------------------------
+#            A web-based GUI for managing and monitoring the
+#          Pacemaker High-Availability cluster resource manager
+#
+# Copyright (c) 2009-2015 SUSE LLC, All Rights Reserved.
+#
+# Author: Tim Serong <tserong@suse.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it would be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Further, this software is distributed without any warranty that it is
+# free of the rightful claim of any third person regarding infringement
+# or the like.  Any license provided herein, whether implied or
+# otherwise, applies only to this software file.  Patent licenses, if
+# any, provided herein do not apply to combinations of this program with
+# other software, or any other product whatsoever.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write the Free Software Foundation,
+# Inc., 59 Temple Place - Suite 330, Boston MA 02111-1307, USA.
+#
+#======================================================================
+
+class TagsController < ApplicationController
+  before_filter :login_required
+  before_filter :set_title
+  before_filter :set_cib
+  before_filter :set_record, only: [:edit, :update, :destroy, :show]
+
+  def index
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: Tag.ordered.to_json
+      end
+    end
+  end
+
+  def new
+    @title = _("Create Tag")
+    @tag = Tag.new
+
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def create
+    normalize_params! params[:tag]
+    @title = _("Create Tag")
+
+    @tag = Tag.new params[:tag]
+
+    respond_to do |format|
+      if @tag.save
+        post_process_for! @tag
+
+        format.html do
+          flash[:success] = _("Tag created successfully")
+          redirect_to edit_cib_tag_url(cib_id: @cib.id, id: @tag.id)
+        end
+        format.json do
+          render json: @tag, status: :created
+        end
+      else
+        format.html do
+          render action: "new"
+        end
+        format.json do
+          render json: @tag.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  def edit
+    @title = _("Edit Tag")
+
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def update
+    normalize_params! params[:tag]
+    @title = _("Edit Tag")
+
+    if params[:revert]
+      return redirect_to edit_cib_tag_url(cib_id: @cib.id, id: @tag.id)
+    end
+
+    respond_to do |format|
+      if @tag.update_attributes(params[:tag])
+        post_process_for! @tag
+
+        format.html do
+          flash[:success] = _("Tag updated successfully")
+          redirect_to edit_cib_tag_url(cib_id: @cib.id, id: @tag.id)
+        end
+        format.json do
+          render json: @tag, status: :updated
+        end
+      else
+        format.html do
+          render action: "edit"
+        end
+        format.json do
+          render json: @tag.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  def destroy
+    respond_to do |format|
+      if Invoker.instance.crm("--force", "configure", "delete", @tag.id)
+        format.html do
+          flash[:success] = _("Tag deleted successfully")
+          redirect_to cib_dashboard_url(cib_id: @cib.id)
+        end
+        format.json do
+          render json: {
+            success: true,
+            message: _("Tag deleted successfully")
+          }
+        end
+      else
+        format.html do
+          flash[:alert] = _("Error deleting %s") % @tag.id
+          redirect_to edit_cib_tag_url(cib_id: @cib.id, id: @tag.id)
+        end
+        format.json do
+          render json: { error: _("Error deleting %s") % @tag.id }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  def show
+    respond_to do |format|
+      format.json do
+        render json: @tag.to_json
+      end
+      format.any { not_found  }
+    end
+  end
+
+  protected
+
+  def set_title
+    @title = _("Tags")
+  end
+
+  def set_cib
+    @cib = Cib.new params[:cib_id], current_user
+  end
+
+  def set_record
+    @tag = Tag.find params[:id]
+
+    unless @tag
+      respond_to do |format|
+        format.html do
+          flash[:alert] = _("The tag does not exist")
+          redirect_to cib_dashboard_url(cib_id: @cib.id)
+        end
+      end
+    end
+  end
+
+  def post_process_for!(record)
+  end
+
+  def normalize_params!(current)
+  end
+
+  def default_base_layout
+    if ["new", "create", "edit", "update"].include? params[:action]
+      "withrightbar"
+    else
+      super
+    end
+  end
+end

--- a/hawk/app/helpers/tag_helper.rb
+++ b/hawk/app/helpers/tag_helper.rb
@@ -74,4 +74,12 @@ module TagHelper
       "{{/for}}"
     ].join("\n").html_safe
   end
+
+  def tag_refs_list
+    options = @cib.resources.map(&:id).sort do |a, b|
+      a.natcmp(b, true)
+    end
+  end
+
+  
 end

--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -386,10 +386,10 @@ class Cib < CibObject
 
     @tags = []
     @xml.elements.each('cib/configuration/tags/tag') do |t|
-      @tags << {
+      @tags << Hashie::Mash.new(
         :id => t.attributes['id'],
         :refs => t.elements.collect('obj_ref') { |ref| ref.attributes['id'] }
-      }
+      )
     end
 
     # Iterate nodes in cib order here which makes the faked up clone & ms instance

--- a/hawk/app/models/record.rb
+++ b/hawk/app/models/record.rb
@@ -69,7 +69,7 @@ class Record < Tableless
           Invoker.instance.cibadmin(
             '-Ql',
             '--xpath',
-            "//configuration//*[self::node or self::primitive or self::template or self::clone or self::group or self::master or self::rsc_order or self::rsc_colocation or self::rsc_location or self::rsc_ticket or self::acl_role or self::acl_target][@#{attr}='#{id}']"
+            "//configuration//*[self::node or self::primitive or self::template or self::clone or self::group or self::master or self::rsc_order or self::rsc_colocation or self::rsc_location or self::rsc_ticket or self::acl_role or self::acl_target or self::tag][@#{attr}='#{id}']"
           )
         )
 
@@ -185,7 +185,8 @@ class Record < Tableless
         rsc_location: Location,
         rsc_ticket: Ticket,
         acl_role: Role,
-        acl_target: User
+        acl_target: User,
+        tag: Tag
       }
 
       @map[name.to_sym]

--- a/hawk/app/views/resources/types.html.haml
+++ b/hawk/app/views/resources/types.html.haml
@@ -25,6 +25,11 @@
           = icon_text "superscript", _("Add a master/slave")
           .pull-right
             = icon_tag "plus-circle"
+      %li
+        = link_to new_cib_tag_path(cib_id: current_cib.id), data: { help_filter: ".tag" }, class: "btn btn-default btn-lg" do
+          = icon_text "tag", _("Add a tag")
+          .pull-right
+            = icon_tag "plus-circle"
 
 - content_for :rightbar do
   .container-fluid{ data: { spy: "affix" } }
@@ -136,6 +141,41 @@
     .row.masterslave
       %h2.margin-bottom
         = _("Add a master/slave")
+
+      %p
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae
+        ab illo inventore veritatis et quasi architecto beatae vitae dicta
+        sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+        aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+        eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+        qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit,
+        sed quia non numquam eius modi tempora incidunt ut labore et dolore
+        magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis
+        nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
+        aliquid ex ea commodi consequatur? Quis autem vel eum iure
+        reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+        consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+        pariatur?
+
+      %p
+        At vero eos et accusamus et iusto odio dignissimos ducimus qui
+        blanditiis praesentium voluptatum deleniti atque corrupti quos
+        dolores et quas molestias excepturi sint occaecati cupiditate non
+        provident, similique sunt in culpa qui officia deserunt mollitia
+        animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis
+        est et expedita distinctio. Nam libero tempore, cum soluta nobis est
+        eligendi optio cumque nihil impedit quo minus id quod maxime placeat
+        facere possimus, omnis voluptas assumenda est, omnis dolor
+        repellendus. Temporibus autem quibusdam et aut officiis debitis aut
+        rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint
+        et molestiae non recusandae. Itaque earum rerum hic tenetur a
+        sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+        consequatur aut perferendis doloribus asperiores repellat.
+
+    .row.masterslave
+      %h2.margin-bottom
+        = _("Add a tag")
 
       %p
         Sed ut perspiciatis unde omnis iste natus error sit voluptatem

--- a/hawk/app/views/shared/_mainnav.html.haml
+++ b/hawk/app/views/shared/_mainnav.html.haml
@@ -83,6 +83,9 @@
         %li{ class: active_menu_with(:tickets) }
           = link_to _("Tickets"), cib_tickets_path(cib_id: current_cib.id)
 
+        %li{ class: active_menu_with(:tags) }
+          = link_to _("Tags"), cib_tags_path(cib_id: current_cib.id)
+
         - if Util.has_feature? :acl_support
           %li{ class: active_menu_with(:templates) }
             = link_to _("Templates"), cib_templates_path(cib_id: current_cib.id)

--- a/hawk/app/views/tags/_form.html.haml
+++ b/hawk/app/views/tags/_form.html.haml
@@ -1,0 +1,36 @@
+.panel.panel-default
+  .panel-body
+    = form_for [cib, tag], horizontal: true do |main_form|
+      = errors_for tag
+
+      - if tag.new_record?
+        = main_form.text_field :id, label: _("Tag ID")
+        /= main_form.select :refs, tag_refs_list, { include_hidden: false, include_blank: true }, id: nil, label: _("Objects")
+      - else
+        = main_form.text_field :id, label: _("Tag ID"), readonly: true
+        /= main_form.text_field :refs, label: _("Objects"), readonly: true
+
+      .form-group
+        %label.col-sm-5.control-label
+          = _("Objects")
+        .col-sm-7
+          %ul.list-group.sortable
+            - if tag_refs_list.empty?
+              %li.list-group-item.text-warning
+                = _('No objects available')
+            - else
+              - tag_refs_list.each do |ref|
+                %li.list-group-item
+                  = check_box_tag "tag[refs][]", ref, tag.refs.include?(ref)
+                  = ref
+                  .pull-right
+                    = icon_tag("bars")
+
+      = main_form.button_group do
+        - if tag.new_record?
+          = create_button(main_form, tag)
+        - else
+          = apply_button(main_form, tag)
+          = revert_button(main_form, tag)
+
+        = link_to _("Back"), types_cib_resources_path(cib_id: cib.id), class: "btn btn-default back"

--- a/hawk/app/views/tags/backup.html.erb
+++ b/hawk/app/views/tags/backup.html.erb
@@ -1,0 +1,72 @@
+<% content_for :head do %>
+<%= stylesheet_link_tag 'ui.attrlist.css' %>
+<%= stylesheet_link_tag 'ui.panel.css' %>
+<%= javascript_include_tag 'jquery.ui.attrlist.js' %>
+<%= javascript_include_tag 'jquery.ui.panel.js' %>
+<% end %>
+<script type="text/javascript">
+
+var anything_changed = false;
+
+var r_meta = <%= Clone.metadata.to_json.html_safe %>;
+
+function enable_apply() {
+  anything_changed = true;
+  if ($("#clone_id").val() != "" && $("#clone_child").val() != "") {
+    $("#clone_submit").removeAttr("disabled");
+    $("#clone_revert").removeAttr("disabled");
+  } else {
+    $("#clone_submit").attr("disabled", "disabled");
+    $("#clone_revert").attr("disabled", "disabled");
+  }
+}
+
+$(function() {
+  $("#clone_id")
+    .bind("keyup change", function() {
+      enable_apply();
+    }).focus();
+  $("#clone_child")
+    .bind("keyup change", function() {
+      enable_apply();
+    }).focus();
+  $("#meta").panel({ label: "<%=h escape_javascript _('Meta Attributes') %>", menu_icon: url_root + "/assets/transparent-16x16.gif" });
+  $("#meta").panel("body_element").attrlist({
+    all_attrs: r_meta.meta,
+    set_attrs: <%= @res.meta.to_json.html_safe %>,
+    prefix: "clone[meta]",
+    labels: {
+      add: "<%= escape_javascript _('Add') %>",
+      remove: "<%= escape_javascript _('Remove') %>",
+      no_value: "<%= escape_javascript _('You must enter a value') %>"
+    },
+    dirty: function(event, info) {
+      // This might be a bit event-heavy
+      enable_apply();
+    }
+  });
+  if (!$("#meta").panel("body_element").attrlist("empty")) {
+    $("#meta").panel("expand");
+  }
+<%= render :partial => 'shared/confirm_revert', :locals => { :button_ids => '#clone_revert,#clone_cancel' } %>
+});
+</script>
+<%= form_for([ @cib, @res ]) do |f| %>
+<table>
+  <tr>
+    <th><%=h f.label :id, _('Clone ID') %></th>
+    <th><%=h f.label :child, _('Child Resource') %></th>
+  </tr>
+  <tr>
+    <td><%= f.text_field :id %></td>
+    <td><%= f.select :child, options_for_select(([@res.child] + @cib.resources.select {|r|
+        !r.has_key?(:children) || (r.has_key?(:children) && r[:type] == 'group')
+      }.map{|r| r[:id] }).sort{|a,b| a.natcmp(b, true)}, @res.child) %></td>
+  </tr>
+  <tr>
+    <td colspan="4">
+      <div id="meta"></div>
+    </td>
+  </tr>
+</table>
+<% end %>

--- a/hawk/app/views/tags/edit.html.haml
+++ b/hawk/app/views/tags/edit.html.haml
@@ -1,0 +1,21 @@
+.container-fluid
+  .row
+    %h1
+      = icon_text "copy", _("Edit Tag"), class: "page"
+      .pull-right
+        .btn-group{ role: "group" }
+          = link_to icon_text("trash", _("Delete")), cib_tag_path(cib_id: @cib.id, id: @tag.id), method: "delete", confirm: _("Are you sure you wish to delete %s?") % @tag.id, class: "btn btn-default"
+
+  .row
+    = render partial: "form", locals: { cib: @cib, tag: @tag }
+
+- content_for :rightbar do
+  .container-fluid{ data: { spy: "affix" } }
+    - @tag.mapping.each do |key, values|
+      - next unless values[:longdesc]
+
+      .row{ class: key }
+        %h2.margin-bottom
+          = key
+
+        = simple_format values[:longdesc]

--- a/hawk/app/views/tags/index.html.haml
+++ b/hawk/app/views/tags/index.html.haml
@@ -1,0 +1,11 @@
+.container-fluid
+  .row
+    %h1
+      = icon_text "copy", _("Tags"), class: "page"
+      .pull-right
+        .btn-group{ role: "group" }
+          = link_to icon_text("plus", _("Create")), new_cib_tag_path, class: "btn btn-default"
+
+  .row
+    .panel.panel-default
+      %table.table.table-striped.tags

--- a/hawk/app/views/tags/new.html.haml
+++ b/hawk/app/views/tags/new.html.haml
@@ -1,0 +1,18 @@
+.container-fluid
+  .row
+    %h1
+      = icon_text "copy", _("Create Tag"), class: "page"
+
+  .row
+    = render partial: "form", locals: { cib: @cib, tag: @tag }
+
+- content_for :rightbar do
+  .container-fluid{ data: { spy: "affix" } }
+    - @tag.mapping.each do |key, values|
+      - next unless values[:longdesc]
+
+      .row{ class: key }
+        %h2.margin-bottom
+          = key
+
+        = simple_format values[:longdesc]

--- a/hawk/config/routes.rb
+++ b/hawk/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
     resources :templates
     resources :roles
     resources :users
+    resources :tags
 
     resource :profile, only: [:edit, :update]
     resource :crm_config, only: [:edit, :update]


### PR DESCRIPTION
Support for creating and editing cluster tags.

Tags are superficially similar to groups, but don't imply any constraints between the resources. They are useful for managing otherwise unrelated resources atomically, for example when moving resources between clusters using booth (geo-clusters).