### PR TITLE
allow adding rules to new location contraints

### DIFF
--- a/hawk/app/assets/javascripts/module/location.js
+++ b/hawk/app/assets/javascripts/module/location.js
@@ -147,6 +147,14 @@
             '</div>',
           '</fieldset>',
         '{{/for}}',
+        '<fieldset>',
+          '<legend>',
+            __('New Rule'),
+            '<div class="pull-right">',
+              '<i class="fa fa-plus rule new"></i> ',
+            '</div>',
+          '</legend>',
+        '</fieldset>',
       ].join('')
     };
 
@@ -217,14 +225,24 @@
           expressions: []
         });
       })
+      .on('click', '.rule.new', function(e) {
+        e.preventDefault();
+
+        $.observable(
+          content['entries']
+        ).insert(content['entries'].length, {
+            score: '-INFINITY',
+            role: '',
+            operator: '',
+            expressions: []
+          });
+      })
       .on('click', '.rule.remove', function(e) {
         e.preventDefault();
 
-        if (content['entries'].length > 1) {
-          $.observable(
-            content['entries']
-          ).remove($.view(this).index);
-        }
+        $.observable(
+          content['entries']
+        ).remove($.view(this).index);
       })
       .on('click', '.expression.remove', function(e) {
         e.preventDefault();


### PR DESCRIPTION
- fixes frontend issue

__Note:__
Alternatively we could always create an empty rule when showing this view for new constraints.
But then we would still need an add-button after the last rule (or reordering buttons).