### PR TITLE
Implement /monitor as a live controller (bsc#947748)

### DIFF
--- a/chef/cookbooks/hawk/templates/default/systemd.service.erb
+++ b/chef/cookbooks/hawk/templates/default/systemd.service.erb
@@ -4,8 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-KillMode=none
+KillMode=control-group
 TimeoutSec=300
+TimeoutStopSec=10
 
 User=hacluster
 Group=haclient
@@ -13,8 +14,8 @@ Group=haclient
 WorkingDirectory=/vagrant/hawk
 
 Environment="HAWK_ENV=development"
-Environment="HAWK_THREADS=2"
-Environment="HAWK_WORKERS=2"
+Environment="HAWK_THREADS=16"
+Environment="HAWK_WORKERS=1"
 Environment="HAWK_LISTEN=0.0.0.0"
 Environment="HAWK_PORT=3000"
 Environment="HAWK_KEY=/vagrant/hawk/tmp/hawk.pem"

--- a/hawk/app/assets/javascripts/module/monitor.js
+++ b/hawk/app/assets/javascripts/module/monitor.js
@@ -114,4 +114,15 @@ $(function() {
   $.updateCib = function() {
     $('body').trigger($.Event('updated.hawk.monitor'));
   };
+
+  $('body').on('updated.hawk.monitor', function() {
+    $(['#states #middle table.resources',
+       '#resources #middle table.resources',
+       '#states #middle table.tickets',
+       '#tickets #middle table.tickets',
+       '#nodes #middle table.nodes',
+       '#states #middle table.nodes'].join(', '))
+      .bootstrapTable('refresh');
+  });
+
 });

--- a/hawk/app/assets/javascripts/module/monitor.js
+++ b/hawk/app/assets/javascripts/module/monitor.js
@@ -34,7 +34,6 @@
   MonitorCheck.prototype.processCheck = function() {
     var self = this;
 
-    console.log("Start monitor:", self.currentEpoch);
     $.ajax({
       url: Routes.monitor_path(),
 
@@ -45,7 +44,6 @@
       timeout: self.options.timeout * 1000,
 
       success: function(data) {
-        console.log("Monitor response:", data);
         if (data) {
           if (self.updateEpoch(data.epoch)) {
             $('body').trigger($.Event('updated.hawk.monitor'));

--- a/hawk/app/assets/javascripts/module/simulator.js
+++ b/hawk/app/assets/javascripts/module/simulator.js
@@ -2,10 +2,6 @@
 // See COPYING for license.
 
 $(function() {
-  var update_cib = function() {
-    // TODO(must): Implement
-  };
-
   var make_error_handler = function(target, postfn) {
     return function(xhr, status, error) {
       console.log(xhr, status, error);
@@ -65,12 +61,13 @@ $(function() {
       $.ajax({
         type: "POST", dataType: "json", url: path, data: data,
         success: function(data) {
-          update_cib();
+          $.updateCib();
           events.find("option").each(function() { $(this).remove(); });
           update_events();
           $btn.button('reset');
         },
         error: make_error_handler(self.find(".errors"), function() {
+          $.updateCib();
           events.find("option").each(function() { $(this).remove(); });
           update_events();
           $btn.button('reset');
@@ -95,11 +92,14 @@ $(function() {
       $.ajax({
         type: "POST", dataType: "json", url: path, data: data,
         success: function(data) {
-          update_cib();
+          $.updateCib();
           self.find("#sim-results").removeAttr("disabled").addClass("btn-success");
           $btn.button('reset');
         },
-        error: make_error_handler(self.find(".errors"), function() { $btn.button('reset'); })
+        error: make_error_handler(self.find(".errors"), function() {
+          $.updateCib();
+          $btn.button('reset');
+        })
       });
     };
 

--- a/hawk/app/controllers/application_controller.rb
+++ b/hawk/app/controllers/application_controller.rb
@@ -10,20 +10,16 @@ class ApplicationController < ActionController::Base
   layout :detect_current_layout
 
   around_filter :inject_current_user
-
+  around_filter :inject_current_cib
   before_filter :set_users_locale
   before_filter :set_current_home
   before_filter :set_current_title
   before_filter :set_shadow_cib
-
-  around_filter :inject_current_cib
-
   before_filter :cors_preflight_check
   after_filter :cors_set_access_control_headers
 
   helper_method :is_god?
   helper_method :logged_in?
-
   helper_method :production_cib
   helper_method :current_cib
   helper_method :current_user

--- a/hawk/app/controllers/monitor_controller.rb
+++ b/hawk/app/controllers/monitor_controller.rb
@@ -7,14 +7,21 @@ require 'open3'
 class MonitorController < ApplicationController
   include ActionController::Live
 
+  skip_around_filter :inject_current_user
+  skip_around_filter :inject_current_cib
+  skip_before_filter :set_users_locale
+  skip_before_filter :set_current_home
+  skip_before_filter :set_current_title
+  skip_before_filter :set_shadow_cib
+  before_filter :login_required
+  skip_before_filter :verify_authenticity_token
+
   def monitor
     ENV['QUERY_STRING'] = request.query_string.to_s
-    ENV['HTTP_ORIGIN'] = request.env['HTTP_ORIGIN']
+    ENV['HTTP_ORIGIN'] = request.headers['Origin']
 
     response.headers['Content-Type'] = 'text/event-stream'
-    response.headers['Access-Control-Allow-Origin'] = request.env['HTTP_ORIGIN']
-    response.headers['Access-Control-Allow-Credentials'] = "true" # may not be necessary
-    Open3.popen3("/usr/sbin/hawk_monitor") do |i, o|
+    Open3.popen2("/usr/sbin/hawk_monitor") do |_i, o, _t|
       result = o.read
       _, body = result.split("\n\n", 2)
       response.stream.write(body.to_s + "\n")

--- a/hawk/app/helpers/application_helper.rb
+++ b/hawk/app/helpers/application_helper.rb
@@ -39,7 +39,7 @@ module ApplicationHelper
       class: current_cib.id,
       data: {
         cib: current_cib.id,
-        monitor: current_cib.epoch,
+        epoch: current_cib.epoch,
         god: is_god?.to_s,
         user: current_user,
         content: current_cib.status.to_json

--- a/hawk/config/environments/development.rb
+++ b/hawk/config/environments/development.rb
@@ -2,8 +2,16 @@
 # See COPYING for license.
 
 Rails.application.configure do
-  config.cache_classes = false
-  config.eager_load = false
+  # Because we have the /monitor controller, we need
+  # to change some settings here. Unfortunately, it
+  # interferes with the auto-reloading of changed code.
+  config.preload_frameworks = true
+  config.allow_concurrency = true
+  config.quiet_assets = false
+  config.cache_classes = true
+  config.eager_load = true
+
+
   config.consider_all_requests_local = true
   config.serve_static_files = true
   config.force_ssl = false

--- a/scripts/hawk.service.bundle_gems.in
+++ b/scripts/hawk.service.bundle_gems.in
@@ -4,10 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-KillMode=process
-KillSignal=SIGINT
+KillMode=control-group
 TimeoutSec=300
-TimeoutStopSec=300
+TimeoutStopSec=10
 
 User=hacluster
 Group=haclient
@@ -16,8 +15,8 @@ WorkingDirectory=@WWW_BASE@/hawk
 
 Environment="GEM_PATH=@GEM_PATH@"
 Environment="HAWK_ENV=production"
-Environment="HAWK_THREADS=1"
-Environment="HAWK_WORKERS=3"
+Environment="HAWK_THREADS=16"
+Environment="HAWK_WORKERS=1"
 Environment="HAWK_LISTEN=0.0.0.0"
 Environment="HAWK_PORT=7630"
 Environment="HAWK_KEY=/etc/hawk/hawk.pem"
@@ -28,6 +27,7 @@ EnvironmentFile=-/etc/sysconfig/hawk
 PermissionsStartOnly=true
 ExecStartPre=@WWW_BASE@/hawk/bin/generate-ssl-cert
 ExecStart=@GEM_PATH@/bin/puma -C @WWW_BASE@/hawk/config/puma.rb
+ExecStop=@GEM_PATH@/bin/pumactl -S @WWW_BASE@/hawk/tmp/pids/puma.state stop
 ExecReload=@GEM_PATH@/bin/pumactl -S @WWW_BASE@/hawk/tmp/pids/puma.state restart
 
 [Install]

--- a/scripts/hawk.service.in
+++ b/scripts/hawk.service.in
@@ -4,10 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-KillMode=process
-KillSignal=SIGINT
+KillMode=control-group
 TimeoutSec=300
-TimeoutStopSec=300
+TimeoutStopSec=10
 
 User=hacluster
 Group=haclient
@@ -15,8 +14,8 @@ Group=haclient
 WorkingDirectory=@WWW_BASE@/hawk
 
 Environment="HAWK_ENV=production"
-Environment="HAWK_THREADS=1"
-Environment="HAWK_WORKERS=3"
+Environment="HAWK_THREADS=16"
+Environment="HAWK_WORKERS=1"
 Environment="HAWK_LISTEN=0.0.0.0"
 Environment="HAWK_PORT=7630"
 Environment="HAWK_KEY=/etc/hawk/hawk.pem"
@@ -27,6 +26,7 @@ EnvironmentFile=-/etc/sysconfig/hawk
 PermissionsStartOnly=true
 ExecStartPre=@WWW_BASE@/hawk/bin/generate-ssl-cert
 ExecStart=/usr/bin/puma -C @WWW_BASE@/hawk/config/puma.rb
+ExecStop=/usr/bin/pumactl -S @WWW_BASE@/hawk/tmp/pids/puma.state stop
 ExecReload=/usr/bin/pumactl -S @WWW_BASE@/hawk/tmp/pids/puma.state restart
 
 [Install]


### PR DESCRIPTION
Implement /monitor as a live controller.

This also disables autoloading in development mode, unfortunately. Either we turn off the live controller and multithreading in development, or we lose autoloading.

* Modifies the systemd service to run puma as a single process with 16 threads.
* Refresh bootstrap tables on epoch change.
* Use /monitor in dashboard.
