### PR TITLE
Fix pull-right icon_tags next to icon_texts in Firefox

### DIFF
--- a/hawk/app/views/constraints/types.html.haml
+++ b/hawk/app/views/constraints/types.html.haml
@@ -10,24 +10,24 @@
     %ul.nav.nav-pills.nav-stacked.nav-bighelp.nav-topspace{ data: { help_target: "#rightbar .rightbar_help > *" } }
       %li
         = link_to new_cib_location_path(cib_id: current_cib.id), data: { help_filter: ".location" }, class: "btn btn-default btn-lg" do
-          = icon_text "globe", _("Location")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "globe", _("Location")
       %li
         = link_to new_cib_colocation_path(cib_id: current_cib.id), data: { help_filter: ".colocation" }, class: "btn btn-default btn-lg" do
-          = icon_text "tasks", _("Colocation")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "tasks", _("Colocation")
       %li
         = link_to new_cib_order_path(cib_id: current_cib.id), data: { help_filter: ".order" }, class: "btn btn-default btn-lg" do
-          = icon_text "sort-amount-desc", _("Order")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "sort-amount-desc", _("Order")
       %li
         = link_to new_cib_ticket_path(cib_id: current_cib.id), data: { help_filter: ".ticket" }, class: "btn btn-default btn-lg" do
-          = icon_text "ticket", _("Ticket")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "ticket", _("Ticket")
 
 - content_for :rightbar do
   .container-fluid{ data: { spy: "affix" } }

--- a/hawk/app/views/resources/types.html.haml
+++ b/hawk/app/views/resources/types.html.haml
@@ -10,29 +10,29 @@
     %ul.nav.nav-pills.nav-stacked.nav-bighelp.nav-topspace
       %li
         = link_to new_cib_primitive_path(cib_id: current_cib.id), data: { help_filter: ".primitive" }, class: "btn btn-default btn-lg" do
-          = icon_text "file-o", _("Primitive")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "file-o", _("Primitive")
       %li
         = link_to new_cib_group_path(cib_id: current_cib.id), data: { help_filter: ".group" }, class: "btn btn-default btn-lg" do
-          = icon_text "group", _("Group")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "group", _("Group")
       %li
         = link_to new_cib_clone_path(cib_id: current_cib.id), data: { help_filter: ".clone" }, class: "btn btn-default btn-lg" do
-          = icon_text "copy", _("Clone")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "copy", _("Clone")
       %li
         = link_to new_cib_master_path(cib_id: current_cib.id), data: { help_filter: ".multistate" }, class: "btn btn-default btn-lg" do
-          = icon_text "superscript", _("Multi-state")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "superscript", _("Multi-state")
       %li
         = link_to new_cib_tag_path(cib_id: current_cib.id), data: { help_filter: ".tag" }, class: "btn btn-default btn-lg" do
-          = icon_text "tag", _("Tag")
           .pull-right
             = icon_tag "plus-circle"
+          = icon_text "tag", _("Tag")
 
 - content_for :rightbar do
   .container-fluid{ data: { spy: "affix" } }

--- a/hawk/app/views/wizards/index.html.haml
+++ b/hawk/app/views/wizards/index.html.haml
@@ -8,13 +8,13 @@
       - wizard_categories(@wizards).each do |category|
         %li.toggable.btn.btn-default.btn-lg
           %span{ href: "##{category}", data: { toggle: "collapse", parent: ".nav-bighelp" } }
+            .pull-right
+              = icon_tag "chevron-down"
+
             - if category == "wizard"
               = icon_text wizard_icon(category), _("Legacy Wizards")
             - else
               = icon_text wizard_icon(category), category.titleize
-
-            .pull-right
-              = icon_tag "chevron-down"
 
           %ul.nav.nav-pills.nav-stacked.collapse{ id: category }
             - @wizards.sort_by(&:name).each do |wizard|
@@ -22,9 +22,9 @@
 
               %li
                 = link_to cib_wizard_path(cib_id: current_cib.id, id: wizard.name), data: { help_filter: ".#{wizard.name}" } do
-                  = wizard.shortdesc
                   .pull-right
                     = icon_tag "plus-circle"
+                  = wizard.shortdesc
 
 - content_for :rightbar do
   .container-fluid.rightbar_help{ data: { spy: "affix" } }


### PR DESCRIPTION
As discussed, it looked broken in Firefox.

Not entirely sure if I found all places where it occurred.
