### PR TITLE
make the footer on login page sticky

### DIFF
--- a/hawk/app/assets/stylesheets/authentication/_basics.scss
+++ b/hawk/app/assets/stylesheets/authentication/_basics.scss
@@ -6,11 +6,17 @@ html {
   min-width: 300px;
 }
 
+html {
+  min-height: 100%;
+  position: relative;
+}
+
 body {
   font-family: "Raleway", sans-serif;
   color: #3a3e40;
   height: 100%;
   cursor: default;
+  margin-bottom: 80px;
 
   background: linear-gradient(to right, #1fad7a 0, #80c235 100%);
   background: -moz-linear-gradient(left, #1fad7a 0, #80c235 100%);

--- a/hawk/app/assets/stylesheets/authentication/_media.scss
+++ b/hawk/app/assets/stylesheets/authentication/_media.scss
@@ -2,6 +2,10 @@
 // See COPYING for license.
 
 @media (max-width: 300px) {
+  body {
+    margin-bottom: 0;
+  }
+
   #content {
     &.darkbar {
       border-radius: 0 !important;


### PR DESCRIPTION
the footer on the login page is rendered differently than the one in the app itself.
and it behaves wrong on small devices while scrolling.

![screenshot from 2015-10-02 15 26 27](https://cloud.githubusercontent.com/assets/5372947/10247522/05b8eeca-691a-11e5-92cc-d1bff114b735.png)

I added some CSS to make it a [sticky footer](http://getbootstrap.com/examples/sticky-footer/).