### PR TITLE
move simulator panel to the top

### DIFF
--- a/hawk/app/assets/javascripts/module/simulator.js
+++ b/hawk/app/assets/javascripts/module/simulator.js
@@ -23,6 +23,10 @@ $(function() {
     self.data("simulation-state", 0);
     self.html($("#simulator").render());
 
+    if (sessionStorage.getItem("simulator-collapsed") == "true") {
+      self.find('#simulator-toggle').click();
+    }
+
     var events = self.find("#sim-events");
 
     var update_events = function() {
@@ -102,6 +106,10 @@ $(function() {
         })
       });
     };
+
+    self.find('#simulator-toggle').click(function() {
+      sessionStorage.setItem("simulator-collapsed", !$(this).hasClass("collapsed"));
+    });
 
     self.find("#sim-addnode").click(function() {
       var content = $("#modal .modal-content");

--- a/hawk/app/views/layouts/application.html.haml
+++ b/hawk/app/views/layouts/application.html.haml
@@ -18,14 +18,12 @@
           = render partial: "shared/mainnav"
 
         #middle.col-xs-12.col-sm-8.col-md-8.col-lg-10
+          - if current_cib.sim?
+            .row
+              = render partial: "shared/simulator"
+
           = render partial: "shared/flash", locals: { flash: flash }
           = yield
-
-          - if current_cib.sim?
-            .container-fluid
-              .row
-                .col-lg-12
-                  = render partial: "shared/simulator"
 
     = render partial: "shared/footer"
     = render partial: "shared/modal"

--- a/hawk/app/views/layouts/withrightbar.html.haml
+++ b/hawk/app/views/layouts/withrightbar.html.haml
@@ -18,12 +18,12 @@
           = render partial: "shared/mainnav"
 
         #middle.col-xs-12.col-sm-8.col-md-8.col-lg-6
+          - if current_cib.sim?
+            .row
+              = render partial: "shared/simulator"
+
           = render partial: "shared/flash", locals: { flash: flash }
           = yield
-
-          - if current_cib.sim?
-            .container-fluid
-              = render partial: "shared/simulator"
 
         #rightbar.visible-lg-block.col-lg-4
           = yield :rightbar

--- a/hawk/app/views/shared/_mainnav.html.haml
+++ b/hawk/app/views/shared/_mainnav.html.haml
@@ -1,10 +1,6 @@
 %ul.nav.sidebar-nav
   %li
     %ul
-      - if current_cib.sim?
-        %li
-          %span.label.label-warning= _("Simulator Active")
-
       %li{ class: active_menu_with(:states) }
         = link_to _("Status"), cib_state_path(cib_id: current_cib.id)
 

--- a/hawk/app/views/shared/_simulator.html.haml
+++ b/hawk/app/views/shared/_simulator.html.haml
@@ -4,7 +4,9 @@
   .panel.panel-warning
     #simulator-heading.panel-heading
       %h3.panel-title
-        %a{href: "#simulator-collapse", role: :button, data: {toggle: :collapse, parent: "#simulator"}, aria: {expanded: true, controls: "simulator-collapse"}}
+        %a#simulator-toggle{ href: "#simulator-collapse", role: :button,
+         data: {toggle: :collapse, parent: "#simulator"},
+         aria: {expanded: true, controls: "simulator-collapse"} }
           = _("Simulator Active")
           .pull-right
             %span.caret

--- a/hawk/app/views/shared/_simulator.html.haml
+++ b/hawk/app/views/shared/_simulator.html.haml
@@ -15,31 +15,29 @@
             .col-sm-12
               .errors
           .row
-            .col-sm-7
-              %select#sim-events.form-control{multiple: true}
-              .row
-                &nbsp;
-              %button#sim-addnode.btn.btn-default.btn-sm{type: :button}
-                = icon_text "plus", _("Node")
-              %button#sim-addop.btn.btn-default.btn-sm{type: :button}
-                = icon_text "plus", _("Operation")
-              - unless current_cib.tickets.empty?
-                %button#sim-addticket.btn.btn-default.btn-sm{type: :button}
-                  = icon_text "plus", _("Ticket")
-              %button#sim-delete.btn.btn-default.btn-sm{type: :button}
-                = icon_tag "minus"
-            .col-sm-5
-              .well
-                %button#sim-results.btn.btn-default{type: :button, disabled: :disabled}
-                  = _("Results")
-      .panel-footer
-        .container-fluid
-          .row
-            .pull-right
-              %button#sim-reset.btn.btn-warning{type: :button}
+            .col-sm-9
+              %select.form-control#sim-events{ multiple: true }
+              .btn-group.btn-group-sm.btn-group-justified
+                .btn-group
+                  %button.btn.btn-default#sim-addnode{ type: :button }
+                    = icon_text "plus", _("Node")
+                .btn-group
+                  %button.btn.btn-default#sim-addop{ type: :button }
+                    = icon_text "plus", _("Operation")
+                - unless current_cib.tickets.empty?
+                  .btn-group
+                    %button.btn.btn-default#sim-addticket{ type: :button }
+                      = icon_text "plus", _("Ticket")
+                .btn-group
+                  %button.btn.btn-default#sim-delete{ type: :button }
+                    = icon_tag "minus"
+            .col-sm-3
+              %button.btn.btn-warning.btn-block#sim-reset{ type: :button }
                 = icon_text "rewind", _("Reset")
-              %button#sim-run.btn.btn-primary{type: :button}
+              %button.btn.btn-primary.btn-block#sim-run{ type: :button }
                 = icon_text "play", _("Run")
+              %button.btn.btn-default.btn-block#sim-results{ type: :button, disabled: :disabled }
+                = _("Results")
 
 %script#sim-results-dialog{type: "text/x-jsrender"}
   .modal-header

--- a/hawk/app/views/shared/_simulator.html.haml
+++ b/hawk/app/views/shared/_simulator.html.haml
@@ -1,11 +1,11 @@
 #simulator-node
 
 %script#simulator{type: "text/x-jsrender"}
-  .panel.panel-default
+  .panel.panel-warning
     #simulator-heading.panel-heading
       %h3.panel-title
         %a{href: "#simulator-collapse", role: :button, data: {toggle: :collapse, parent: "#simulator"}, aria: {expanded: true, controls: "simulator-collapse"}}
-          = _("Simulator")
+          = _("Simulator Active")
           .pull-right
             %span.caret
     #simulator-collapse.panel-collapse.collapse.in{aria: {labelledby: "simulator-heading"}}


### PR DESCRIPTION
It's now in a better place than before for sure.
All my more fancy ideas would have broken the mobile views or made them way more complicated.
This is simple but OK I guess.