### PR TITLE
WIP - slide in the simulator from the right

### DIFF
--- a/hawk/app/assets/javascripts/application.js
+++ b/hawk/app/assets/javascripts/application.js
@@ -32,6 +32,7 @@
 //= require module/reports
 //= require module/simulator
 //= require module/location
+//= require bigSlide
 
 $(function() {
   var resize = function() {
@@ -69,7 +70,9 @@ $(function() {
   );
 
   $(window).on(
-    'load',
-    createMutationObserver
+    'load', function(){
+      createMutationObserver();
+      $('.menu-link').bigSlide({side: 'right', menuWidth: '500px'});
+    }
   );
 });

--- a/hawk/app/assets/javascripts/bigSlide.js
+++ b/hawk/app/assets/javascripts/bigSlide.js
@@ -1,0 +1,225 @@
+/*! bigSlide - v0.9.0 - 2015-06-20
+* http://ascott1.github.io/bigSlide.js/
+* Copyright (c) 2015 Adam D. Scott; Licensed MIT */
+(function (factory) {
+  'use strict';
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // Node/CommonJS
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function($) {
+  'use strict';
+
+  // where inlineCSS is the string value of an element's style attribute
+  // and toRemove is a string of space-separated CSS properties,
+  // _cleanInlineCSS removes the CSS declaration for each property in toRemove from inlineCSS
+  // and returns the resulting string
+  function _cleanInlineCSS(inlineCSS, toRemove){
+    var inlineCSSArray  = inlineCSS.split(';');
+    var toRemoveArray   = toRemove.split(' ');
+
+    var cleaned         = '';
+    var keep;
+
+    for (var i = 0, j = inlineCSSArray.length; i < j; i++) {
+      keep = true;
+      for (var a = 0, b = toRemoveArray.length; a < b; a++) {
+        if (inlineCSSArray[i] === '' || inlineCSSArray[i].indexOf(toRemoveArray[a]) !== -1) {
+          keep = false;
+        }
+      }
+      if(keep) {cleaned += inlineCSSArray[i] + '; ';}
+    }
+
+    return cleaned;
+  }
+
+
+  $.fn.bigSlide = function(options) {
+    // store the menuLink in a way that is globally accessible
+    var menuLink = this;
+
+    // plugin settings
+    var settings = $.extend({
+      'menu': ('#menu'),
+      'push': ('.push'),
+      'side': 'left',
+      'menuWidth': '15.625em',
+      'speed': '300',
+      'state': 'closed',
+      'activeBtn': 'active',
+      'easyClose': false,
+      'beforeOpen': function () {},
+      'afterOpen': function() {},
+      'beforeClose': function() {},
+      'afterClose': function() {}
+    }, options);
+
+    // CSS properties set by bigSlide.js on all implicated DOM elements
+    var baseCSSDictionary = 'transition -o-transition -ms-transition -moz-transitions webkit-transition ' + settings.side;
+
+    var model = {
+      //CSS properties set by bigSlide.js on this.$menu
+      menuCSSDictionary: baseCSSDictionary + ' position top bottom height width',
+      //CSS properties set by bigSlide.js on this.$push
+      pushCSSDictionary: baseCSSDictionary,
+      // store the menu's state in the model
+      'state': settings.state
+    };
+
+    // talk back and forth between the view and state
+    var controller = {
+      init: function(){
+        view.init();
+      },
+      
+      // remove bigSlide behavior from the menu
+      _destroy: function(){
+        view._destroy();
+
+        delete menuLink.bigSlideAPI;
+
+        // return a reference to the DOM selection bigSlide.js was called on
+        // so that the destroy method is chainable
+        return menuLink;
+      },
+
+      // update the menu's state
+      changeState: function(){
+        if (model.state === 'closed') {
+          model.state = 'open'
+        } else {
+          model.state = 'closed'
+        }
+      },
+
+      // check the menu's state
+      getState: function(){
+        return model.state;
+      }
+    };
+
+    // the view contains all of the visual interactions
+    var view = {
+      init: function(){
+        // cache DOM values
+        this.$menu = $(settings.menu);
+        this.$push = $(settings.push);
+        this.width = settings.menuWidth;
+
+        // CSS for how the menu will be positioned off screen
+        var positionOffScreen = {
+          'position': 'fixed',
+          'top': '100px',
+          //'bottom': '0',
+          //'height': '400px',
+          'z-index': 100
+        };
+
+        // manually add the settings values
+        positionOffScreen[settings.side] = '-' + settings.menuWidth;
+        positionOffScreen.width = settings.menuWidth;
+
+        // add the css values to position things offscreen
+        if (settings.state === 'closed') {
+          this.$menu.css(positionOffScreen);
+          this.$push.css(settings.side, '0');
+        }
+
+        // css for the sliding animation
+        var animateSlide = {
+          '-webkit-transition': settings.side + ' ' + settings.speed + 'ms ease',
+          '-moz-transition': settings.side + ' ' + settings.speed + 'ms ease',
+          '-ms-transition': settings.side + ' ' + settings.speed + 'ms ease',
+          '-o-transition': settings.side + ' ' + settings.speed + 'ms ease',
+          'transition': settings.side + ' ' + settings.speed + 'ms ease'
+        };
+
+        // add the animation css
+        this.$menu.css(animateSlide);
+        this.$push.css(animateSlide);
+
+        // register a click listener for desktop & touchstart for mobile
+        menuLink.on('click.bigSlide touchstart.bigSlide', function(e) {
+          e.preventDefault();
+          if (controller.getState() === 'open') {
+            view.toggleClose();
+          } else {
+            view.toggleOpen();
+          }
+        });
+
+        // this makes my eyes bleed, but adding it back in as it's a highly requested feature
+        if (settings.easyClose) {
+          $(document).on('click.bigSlide', function(e) {
+           if (!$(e.target).parents().andSelf().is(menuLink) && !$(e.target).closest(menu).length &&  controller.getState() === 'open')  {
+             view.toggleClose();
+           }
+          });
+        }
+      },
+      
+      _destroy: function(){
+        //remove inline styles generated by bigSlide.js while preserving any other inline styles
+        this.$menu.each(function(){
+          var $this = $(this);
+          $this.attr( 'style', _cleanInlineCSS($this.attr('style'), model.menuCSSDictionary).trim() );
+        });
+
+        this.$push.each(function(){
+          var $this = $(this);
+          $this.attr( 'style', _cleanInlineCSS($this.attr('style'), model.pushCSSDictionary).trim() );
+        });
+
+        //remove active class and unbind bigSlide event handlers
+        menuLink
+          .removeClass(settings.activeBtn)
+          .off('click.bigSlide touchstart.bigSlide');
+
+        //release DOM references to avoid memory leaks
+        this.$menu = null;
+        this.$push = null;
+      },
+      
+      // toggle the menu open
+      toggleOpen: function() {
+        settings.beforeOpen();
+        controller.changeState();
+        this.$menu.css(settings.side, '0');
+        this.$push.css(settings.side, this.width);
+        menuLink.addClass(settings.activeBtn);
+        settings.afterOpen();
+      },
+
+      // toggle the menu closed
+      toggleClose: function() {
+        settings.beforeClose();
+        controller.changeState();
+        this.$menu.css(settings.side, '-' + this.width);
+        this.$push.css(settings.side, '0');
+        menuLink.removeClass(settings.activeBtn);
+        settings.afterClose();
+      }
+
+    }
+
+    controller.init();
+
+    this.bigSlideAPI = {
+      settings: settings,
+      model: model,
+      controller: controller,
+      view: view,
+      destroy: controller._destroy
+    };
+
+    return this;
+  };
+
+}));

--- a/hawk/app/views/layouts/application.html.haml
+++ b/hawk/app/views/layouts/application.html.haml
@@ -22,10 +22,8 @@
           = yield
 
           - if current_cib.sim?
-            .container-fluid
-              .row
-                .col-lg-12
-                  = render partial: "shared/simulator"
+            %nav#menu.panel{ role: "navigation" }
+              = render partial: "shared/simulator"
 
     = render partial: "shared/footer"
     = render partial: "shared/modal"

--- a/hawk/app/views/layouts/withrightbar.html.haml
+++ b/hawk/app/views/layouts/withrightbar.html.haml
@@ -22,7 +22,7 @@
           = yield
 
           - if current_cib.sim?
-            .container-fluid
+            %nav#menu.panel{ role: "navigation" }
               = render partial: "shared/simulator"
 
         #rightbar.visible-lg-block.col-lg-4

--- a/hawk/app/views/shared/_simulator.html.haml
+++ b/hawk/app/views/shared/_simulator.html.haml
@@ -15,23 +15,22 @@
             .col-sm-12
               .errors
           .row
-            .col-sm-7
-              %select#sim-events.form-control{multiple: true}
-              .row
-                &nbsp;
-              %button#sim-addnode.btn.btn-default.btn-sm{type: :button}
-                = icon_text "plus", _("Node")
-              %button#sim-addop.btn.btn-default.btn-sm{type: :button}
-                = icon_text "plus", _("Operation")
-              - unless current_cib.tickets.empty?
-                %button#sim-addticket.btn.btn-default.btn-sm{type: :button}
-                  = icon_text "plus", _("Ticket")
-              %button#sim-delete.btn.btn-default.btn-sm{type: :button}
-                = icon_tag "minus"
-            .col-sm-5
-              .well
-                %button#sim-results.btn.btn-default{type: :button, disabled: :disabled}
-                  = _("Results")
+            %select#sim-events.form-control{multiple: true}
+            .row
+              &nbsp;
+            %button#sim-addnode.btn.btn-default.btn-sm{type: :button}
+              = icon_text "plus", _("Node")
+            %button#sim-addop.btn.btn-default.btn-sm{type: :button}
+              = icon_text "plus", _("Operation")
+            - unless current_cib.tickets.empty?
+              %button#sim-addticket.btn.btn-default.btn-sm{type: :button}
+                = icon_text "plus", _("Ticket")
+            %button#sim-delete.btn.btn-default.btn-sm{type: :button}
+              = icon_tag "minus"
+          .row
+            .well
+              %button#sim-results.btn.btn-default{type: :button, disabled: :disabled}
+                = _("Results")
       .panel-footer
         .container-fluid
           .row

--- a/hawk/app/views/shared/_usernav.html.haml
+++ b/hawk/app/views/shared/_usernav.html.haml
@@ -5,6 +5,8 @@
         = link_to navbar_item(_("Simulator"), "toggle-off"), cib_state_path(cib_id: current_user, init_cib: true), class: "simulator", title: _("Enable the simulation mode")
     - else
       %li
+        = link_to navbar_item("Show/hide Simulator", "eye-slash"), "#menu", class: "menu-link"
+      %li
         = link_to navbar_item(_("Disable Simulator"), "toggle-on"), cib_state_path(cib_id: "live"), class: "production", title: _("Disable the simulation mode")
 
   %li


### PR DESCRIPTION
OK, this is another attempt for the simulator placing. Other than #55 this one slides in from the right like @tboerger suggested.

__It's not done!__ I just want to show both of you how it looks so far.
I have not changed the content of simulator-panel much. You might dislike the general idea, so I will wait until I get a "go" for this approach. Like Thomas suggested, the toggle-Button should probably be on the right screen border and not in the top navbar... So don't nitpick yet on such thing (or the naming of the ids)

Also note that I use the jQuery library [bigSlide.js](http://ascott1.github.io/bigSlide.js) and that I had to change its source code a bit to get what we want. (only the CSS rules but still)

So do you like this (in general) better than #55? Personally I don't know. #55 is more mobile-friendly I guess and way simpler.