### PR TITLE
enable 404 page only in production

### DIFF
--- a/hawk/config/routes.rb
+++ b/hawk/config/routes.rb
@@ -132,5 +132,8 @@ Rails.application.routes.draw do
 
   get "login" => "sessions#new", :as => :login
   match 'login' => "sessions#create", via: [ :post, :options], :as => :signin
-  get '*path' => redirect('/') # if nothing else matches
+
+  if Rails.env.production?
+    get '*path' => redirect('/404.html') # if nothing else matches
+  end
 end

--- a/hawk/public/404.html
+++ b/hawk/public/404.html
@@ -10,7 +10,10 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 
     <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/assets/vendor.css" />
     <link rel="stylesheet" href="/assets/application.css" />
+    <link rel="stylesheet" href="/assets/authentication.css" />
+    <script src="/assets/vendor.js"></script>
     <script src="/assets/application.js"></script>
 
     <!--[if lt IE 9]>
@@ -29,7 +32,7 @@
         <div id="navbar" class="navbar-right">
           <ul class="nav navbar-nav">
             <li>
-              <a href="/">Go to dashboard</a>
+              <a href="#" onclick="window.history.back()">Go back</a>
             </li>
           </ul>
         </div>
@@ -37,7 +40,7 @@
     </div>
 
     <div class="container" id="errorpage">
-      <div class="panel panel-default panel-warning">
+      <div class="panel panel-default panel-warning" style="margin-top: 80px;">
         <div class="panel-heading">
           <h2>
             We can't find the page you're looking for
@@ -50,16 +53,16 @@
           </p>
         </div>
       </div>
-
-      <footer>
-        <div class="container-fluid">
-          <div class="col-lg-12 copyright">
-            <p>
-              Copyright &copy; 2009-2015 SUSE, LLC
-            </p>
-          </div>
-        </div>
-      </footer>
     </div>
+
+    <footer>
+      <div class="container-fluid">
+        <div class="col-lg-12 copyright">
+          <p>
+            Copyright &copy; 2009-2015 SUSE, LLC
+          </p>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
Like discussed in #59, this fixes the existing 404 page and uses it in production mode if no other route matches.

The HTML was missing the vendor assets and had the same broken footer behaviour than the authentication page had before we fixed it. To not duplicate the CSS and JS, the 404 page now includes the styles of the authentication page:
![screen shot 2015-11-09 at 15 56 25](https://cloud.githubusercontent.com/assets/5372947/11036723/7e3af9e4-86fa-11e5-9c88-d02e2af4c4fc.png)
