### PR TITLE
Dev: Better server configuration and management

### DIFF
--- a/chef/cookbooks/hawk/templates/default/systemd.service.erb
+++ b/chef/cookbooks/hawk/templates/default/systemd.service.erb
@@ -14,12 +14,6 @@ Group=haclient
 WorkingDirectory=/vagrant/hawk
 
 Environment="HAWK_ENV=development"
-Environment="HAWK_THREADS=16"
-Environment="HAWK_WORKERS=1"
-Environment="HAWK_LISTEN=0.0.0.0"
-Environment="HAWK_PORT=3000"
-Environment="HAWK_KEY=/vagrant/hawk/tmp/hawk.key"
-Environment="HAWK_CERT=/vagrant/hawk/tmp/hawk.pem"
 
 # Run ExecStartPre with root-permissions
 PermissionsStartOnly=true

--- a/hawk/bin/hawk
+++ b/hawk/bin/hawk
@@ -36,7 +36,8 @@ hawk_log() {
 }
 
 hawk_server() {
-	sudo systemctl start hawk-development
+	hawk_stop #stop any other running instance of the puma server
+	HAWK_ENV=development LOGGER=stdout /usr/bin/puma -C /vagrant/hawk/config/puma.rb
 }
 
 if [ $# -lt 1 ]
@@ -64,7 +65,7 @@ case "$1" in
 	log)
 		hawk_log
 		;;
-	server)
+	server|s)
 		hawk_server
 		;;
 	*)

--- a/hawk/bin/hawk
+++ b/hawk/bin/hawk
@@ -3,7 +3,7 @@
 # a simple script to simplify hawk development
 
 usage() {
-	echo "hawk <start|stop|status|restart|log|syslog>"
+	echo "hawk <start|stop|status|restart|log|syslog|server>"
 }
 
 hawk_start() {
@@ -35,6 +35,10 @@ hawk_log() {
 	less +F /vagrant/hawk/log/development.log
 }
 
+hawk_server() {
+	sudo systemctl start hawk-development
+}
+
 if [ $# -lt 1 ]
 then
 	usage
@@ -59,6 +63,9 @@ case "$1" in
 		;;
 	log)
 		hawk_log
+		;;
+	server)
+		hawk_server
 		;;
 	*)
 		usage

--- a/hawk/config/environments/development.rb
+++ b/hawk/config/environments/development.rb
@@ -57,4 +57,6 @@ Rails.application.configure do
   config.logger = ActiveSupport::TaggedLogging.new(
     Logger.new(Rails.root.join("log", "development.log"))
   )
+  # Log into STDOUT (Rails logs) when starting the Puma server
+  config.logger = Logger.new(STDOUT)
 end

--- a/hawk/config/environments/development.rb
+++ b/hawk/config/environments/development.rb
@@ -52,11 +52,9 @@ Rails.application.configure do
   config.i18n.fallbacks = false
 
   config.log_level = :debug
-  config.log_tags = []
+  # Prints Logs to STDOUT when starting the Puma server in development mode with
+  # the environment variable LOGGER is set to stdout
+  # The default is Rails.root/log/development.log
+  config.logger = Logger.new(STDOUT) if ENV["LOGGER"] == "stdout"
 
-  config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new(Rails.root.join("log", "development.log"))
-  )
-  # Log into STDOUT (Rails logs) when starting the Puma server
-  config.logger = Logger.new(STDOUT)
 end

--- a/hawk/config/environments/production.rb
+++ b/hawk/config/environments/production.rb
@@ -43,7 +43,10 @@ Rails.application.configure do
   config.log_level = :warn
   config.log_tags = []
 
-  config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new(STDOUT)
-  )
+  # Log into STDOUT (Rails logs) when starting the Puma server in production
+  config.logger = Logger.new(STDOUT)
+
+  # config.logger = ActiveSupport::TaggedLogging.new(
+  #   Logger.new(STDOUT)
+  # )
 end

--- a/hawk/config/environments/production.rb
+++ b/hawk/config/environments/production.rb
@@ -41,12 +41,6 @@ Rails.application.configure do
   config.i18n.fallbacks = true
 
   config.log_level = :warn
-  config.log_tags = []
 
-  # Log into STDOUT (Rails logs) when starting the Puma server in production
   config.logger = Logger.new(STDOUT)
-
-  # config.logger = ActiveSupport::TaggedLogging.new(
-  #   Logger.new(STDOUT)
-  # )
 end

--- a/hawk/config/environments/test.rb
+++ b/hawk/config/environments/test.rb
@@ -39,7 +39,6 @@ Rails.application.configure do
   config.log_level = :debug
   config.log_tags = []
 
-  # Log into STDOUT (Rails logs) when starting the Puma server in test
   config.logger = Logger.new(STDOUT)
 
   config.active_support.test_order = :random

--- a/hawk/config/environments/test.rb
+++ b/hawk/config/environments/test.rb
@@ -39,9 +39,8 @@ Rails.application.configure do
   config.log_level = :debug
   config.log_tags = []
 
-  config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new(Rails.root.join("log", "test.log"))
-  )
+  # Log into STDOUT (Rails logs) when starting the Puma server in test
+  config.logger = Logger.new(STDOUT)
 
   config.active_support.test_order = :random
 end

--- a/hawk/config/puma.rb
+++ b/hawk/config/puma.rb
@@ -1,47 +1,43 @@
-# Copyright (c) 2009-2015 Tim Serong <tserong@suse.com>
-# See COPYING for license.
-
 require 'fileutils'
 
 ROOT = File.expand_path("../../", __FILE__)
-ENVIRONMENT = ENV["HAWK_ENV"] || "production"
 
-THREADS = ENV["HAWK_THREADS"] || 1
-WORKERS = ENV["HAWK_WORKERS"] || 2
+def set_conf(*args)
+  # Setting configuration variables (using parallel assignment)
+  @environment, @threads, @workers, @listen, @port, @key, @cert = args
+end
 
-LISTEN = ENV["HAWK_LISTEN"] || "0.0.0.0"
-PORT = ENV["HAWK_PORT"] || "7630"
-
-KEY = ENV["HAWK_KEY"] || "/etc/hawk/hawk.key"
-CERT = ENV["HAWK_CERT"] || "/etc/hawk/hawk.pem"
+if ENV["HAWK_ENV"] == "development"
+  set_conf("development", 1, 2, "0.0.0.0", "3000", "/vagrant/hawk/tmp/hawk.key",
+           "/etc/hawk/hawk.pem")
+  bind "tcp://#{@listen}:#{@port}"
+else
+  set_conf(ENV["HAWK_ENV"] || "production",
+           ENV["HAWK_THREADS"] || 1,
+           ENV["HAWK_WORKERS"] || 2,
+           ENV["HAWK_LISTEN"] || "0.0.0.0",
+           ENV["HAWK_PORT"] || "7630",
+           ENV["HAWK_KEY"] || "/etc/hawk/hawk.key",
+           ENV["HAWK_CERT"] || "/etc/hawk/hawk.pem")
+  ssl_bind @listen, @port, cert: @cert, key: @key
+end
 
 directory ROOT
-environment ENVIRONMENT
+environment @environment
 
 tag "hawk"
 
 daemonize false
 prune_bundler false
 
-threads 0, THREADS
+threads 0, @threads
 
-workers WORKERS
+workers @workers
 worker_timeout 60
 
 pidfile File.join(ROOT, "tmp", "pids", "puma.pid")
 state_path File.join(ROOT, "tmp", "pids", "puma.state")
 
-if ENVIRONMENT == "development"
-  bind "tcp://#{LISTEN}:#{PORT}"
-else
-  ssl_bind LISTEN, PORT, cert: CERT, key: KEY
-end
-
-[
-  "tmp/pids",
-  "tmp/sessions",
-  "tmp/sockets",
-  "tmp/cache"
-].each do |name|
+["tmp/pids", "tmp/sessions", "tmp/sockets", "tmp/cache"].each do |name|
   FileUtils.mkdir_p File.join(ROOT, name)
 end

--- a/hawk/config/puma.rb
+++ b/hawk/config/puma.rb
@@ -2,23 +2,22 @@ require 'fileutils'
 
 ROOT = File.expand_path("../../", __FILE__)
 
-def set_conf(*args)
-  # Setting configuration variables (using parallel assignment)
+def set_config(*args)
   @environment, @threads, @workers, @listen, @port, @key, @cert = args
 end
 
 if ENV["HAWK_ENV"] == "development"
-  set_conf("development", 1, 2, "0.0.0.0", "3000", "/vagrant/hawk/tmp/hawk.key",
-           "/etc/hawk/hawk.pem")
+  set_config("development", 16, 1, "0.0.0.0", "3000", "/vagrant/hawk/tmp/hawk.key",
+             "/etc/hawk/hawk.pem")
   bind "tcp://#{@listen}:#{@port}"
 else
-  set_conf(ENV["HAWK_ENV"] || "production",
-           ENV["HAWK_THREADS"] || 1,
-           ENV["HAWK_WORKERS"] || 2,
-           ENV["HAWK_LISTEN"] || "0.0.0.0",
-           ENV["HAWK_PORT"] || "7630",
-           ENV["HAWK_KEY"] || "/etc/hawk/hawk.key",
-           ENV["HAWK_CERT"] || "/etc/hawk/hawk.pem")
+  set_config(ENV["HAWK_ENV"] || "production",
+             ENV["HAWK_THREADS"] || 16,
+             ENV["HAWK_WORKERS"] || 1,
+             ENV["HAWK_LISTEN"] || "0.0.0.0",
+             ENV["HAWK_PORT"] || "7630",
+             ENV["HAWK_KEY"] || "/etc/hawk/hawk.key",
+             ENV["HAWK_CERT"] || "/etc/hawk/hawk.pem")
   ssl_bind @listen, @port, cert: @cert, key: @key
 end
 

--- a/rpm/sysconfig.hawk
+++ b/rpm/sysconfig.hawk
@@ -1,5 +1,5 @@
 ## Path:            Cluster/Hawk
-## Description:     Mode of operation 
+## Description:     Mode of operation
 ## Type:            string(production,development,test)
 ## Default:         production
 ## ServiceRestart:  hawk

--- a/rpm/sysconfig.hawk
+++ b/rpm/sysconfig.hawk
@@ -14,7 +14,7 @@ HAWK_ENV="production"
 ## Default:         1
 ## ServiceRestart:  hawk
 # Sets the maximum number of threads used by the web server.
-HAWK_THREADS="1"
+HAWK_THREADS="16"
 
 ## Path:            Cluster/Hawk
 ## Description:     Maximum number of worker processes
@@ -23,7 +23,7 @@ HAWK_THREADS="1"
 ## ServiceRestart:  hawk
 # Sets the maximum number of separate worker processes spawned by the
 # web server.
-HAWK_WORKERS="2"
+HAWK_WORKERS="1"
 
 ## Path:            Cluster/Hawk
 ## Description:     Listen address

--- a/scripts/hawk.service.bundle_gems.in
+++ b/scripts/hawk.service.bundle_gems.in
@@ -15,12 +15,6 @@ WorkingDirectory=@WWW_BASE@/hawk
 
 Environment="GEM_PATH=@GEM_PATH@"
 Environment="HAWK_ENV=production"
-Environment="HAWK_THREADS=16"
-Environment="HAWK_WORKERS=1"
-Environment="HAWK_LISTEN=0.0.0.0"
-Environment="HAWK_PORT=7630"
-Environment="HAWK_KEY=/etc/hawk/hawk.key"
-Environment="HAWK_CERT=/etc/hawk/hawk.pem"
 EnvironmentFile=-/etc/sysconfig/hawk
 
 # Run ExecStartPre with root-permissions

--- a/scripts/hawk.service.in
+++ b/scripts/hawk.service.in
@@ -14,12 +14,6 @@ Group=haclient
 WorkingDirectory=@WWW_BASE@/hawk
 
 Environment="HAWK_ENV=production"
-Environment="HAWK_THREADS=16"
-Environment="HAWK_WORKERS=1"
-Environment="HAWK_LISTEN=0.0.0.0"
-Environment="HAWK_PORT=7630"
-Environment="HAWK_KEY=/etc/hawk/hawk.key"
-Environment="HAWK_CERT=/etc/hawk/hawk.pem"
 EnvironmentFile=-/etc/sysconfig/hawk
 
 # Run ExecStartPre with root-permissions


### PR DESCRIPTION
Refactoring the puma.rb file, removing the duplication from systemd and sysconfig.hawk files, modifying the logging output for the development mode and provide a hawk command for starting the puma server with stdout logs: hawk server - hawk s (shortcut).