### PR TITLE
Dev: Check whether param's value is blank

### DIFF
--- a/hawk/app/models/primitive.rb
+++ b/hawk/app/models/primitive.rb
@@ -28,6 +28,16 @@ class Primitive < Template
   alias_method :provider_without_template, :provider
   alias_method :provider, :provider_with_template
 
+  validate :validate_params
+
+  def validate_params
+    params.each do |param, value|
+      if value.blank?
+        errors.add(:base, "In Parameters, #{param}'s value is blank!")
+      end
+    end
+  end
+
   def type_with_template
     if template.present?
       ::Template.find(template).try(:type)


### PR DESCRIPTION
Hi:
   For now,  Primitive resource will be successfully created when some parameters are still blank.
   This will cause errors at pacemaker(see crm_mon).
   We can't prevent user input an invalid parameter, but we can prevent them leaving a blank one.


   This is my first try on Hawk/rails:) 
   Regards,
   xin
   