### PR TITLE
Dev: Replace type="string" to 'type="text" in ra's meta-data

### DIFF
--- a/hawk/app/controllers/agents_controller.rb
+++ b/hawk/app/controllers/agents_controller.rb
@@ -22,7 +22,7 @@ class AgentsController < ApplicationController
     else
       @name = params[:id]
     end
-    @agent = Hash.from_xml(Util.safe_x("/usr/sbin/crm_resource", "--show-metadata", @name))
+    @agent = Hash.from_xml(Util.safe_x("/usr/sbin/crm_resource", "--show-metadata", @name).gsub(/type="string"/, 'type="text"'))
 
     if @agent
       respond_to do |format|


### PR DESCRIPTION
If don't do this, the default value of params will lost after converting from xml to json
 
e.g. RA vsftpd and mysql has many default values, but they cant be shown on the web, it's strange.
Hash.from_xml will cause the default value lost if the value's type is "string" 
related link:
https://stackoverflow.com/questions/14891912/rails-hash-from-xml-not-giving-expected-results
