### PR TITLE
Dev: Convert hash's key to symbol

### DIFF
--- a/hawk/app/controllers/locations_controller.rb
+++ b/hawk/app/controllers/locations_controller.rb
@@ -48,6 +48,7 @@ class LocationsController < ApplicationController
         expressions: []
       )
     end
+    @location.rules = Util.map_value(@location.rules)
 
     respond_to do |format|
       if @location.save

--- a/hawk/app/lib/util.rb
+++ b/hawk/app/lib/util.rb
@@ -360,4 +360,25 @@ module Util
     elem ? (elem.text.strip || '') : ''
   end
   module_function :get_xml_text
+
+  # https://apidock.com/rails/v4.2.7/Hash/deep_symbolize_keys
+  def symbolize_rescursive(hash)
+    {}.tap do |h|
+      hash.each { |key, value| h[key.to_sym] = map_value(value) }
+    end
+  end
+  module_function :symbolize_rescursive
+
+  # https://apidock.com/rails/v4.2.7/Hash/deep_symbolize_keys
+  def map_value(thing)
+    case thing
+    when Hash
+      symbolize_rescursive(thing)
+    when Array
+      thing.map { |v| map_value(v) }
+    else
+      thing
+    end
+  end
+  module_function :map_value
 end

--- a/hawk/app/models/colocation.rb
+++ b/hawk/app/models/colocation.rb
@@ -92,6 +92,7 @@ class Colocation < Constraint
       # Have to clone out of @resources, else we've just got references
       # to elements of @resources inside collapsed, which causes @resources
       # to be modified, which we *really* don't want.
+      @resources = Util.map_value(@resources)
       collapsed = [ @resources.first.clone ]
       @resources.last(@resources.length - 1).each do |set|
         if collapsed.last[:sequential] == set[:sequential] &&


### PR DESCRIPTION
If don't do this, there will case some crashes(in location.rb) when adding location constraint,
because key's type in hash is not symbol.
Rails has an api called deep_symbolize_keys,
but I think use a common way(mentioned in https://apidock.com/rails/v4.2.7/Hash/deep_symbolize_keys) is also accepted:)