### PR TITLE
Dev: Make sure no errors before crm configure verify

### DIFF
--- a/hawk/app/models/constraint.rb
+++ b/hawk/app/models/constraint.rb
@@ -11,7 +11,7 @@ class Constraint < Record
     # to validate a new record:
     # try making the shell form and running verify;commit in a temporary shadow cib in crm
     # if it fails, report errors
-    if record.new_record && current_cib.live?
+    if record.errors.blank? && record.new_record && current_cib.live?
       cli = record.shell_syntax
       _out, err, rc = Invoker.instance.no_log do |i|
         i.crm_configure ['cib new', cli, 'verify', 'commit'].join("\n")

--- a/hawk/app/models/resource.rb
+++ b/hawk/app/models/resource.rb
@@ -19,7 +19,7 @@ class Resource < Record
     # to validate a new record:
     # try making the shell form and running verify;commit in a temporary shadow cib in crm
     # if it fails, report errors
-    if record.new_record && current_cib.live?
+    if record.errors.blank? && record.new_record && current_cib.live?
       cli = record.shell_syntax
       _out, err, rc = Invoker.instance.no_log do |i|
         i.crm_configure ['cib new', cli, 'verify', 'commit'].join("\n")


### PR DESCRIPTION
When adding resources or constraints, we use "crm configure" to verify commits;
Before that, we have already done some checks, such as id's presence and resources.length for colocation, it's better to make sure that these checks have passed successfully, and then, let "crm configure" to verify

Regards,
xin
