### PR TITLE
Dev: Move get_meta_data function to util and do some replaces

### DIFF
--- a/hawk/app/controllers/agents_controller.rb
+++ b/hawk/app/controllers/agents_controller.rb
@@ -22,7 +22,7 @@ class AgentsController < ApplicationController
     else
       @name = params[:id]
     end
-    @agent = Hash.from_xml(Util.safe_x("/usr/sbin/crm_resource", "--show-metadata", @name).gsub(/type="string"/, 'type="text"'))
+    @agent = Hash.from_xml(Util.get_meta_data(@name))
 
     if @agent
       respond_to do |format|

--- a/hawk/app/lib/util.rb
+++ b/hawk/app/lib/util.rb
@@ -354,6 +354,16 @@ module Util
   end
   module_function :acl_version
 
+  def get_meta_data(agent)
+    res = safe_x("/usr/sbin/crm_resource", "--show-metadata", agent)
+    sub_map = { 'type="string"' => 'type="text"',
+                '(type="boolean".*)default="(yes|1)"' => '\1default="true"',
+                '(type="boolean".*)default="(no|0)"' => '\1default="false"' }
+    sub_map.each { |k,v| res.gsub!(/#{k}/i, v) }
+    res
+  end
+  module_function :get_meta_data
+
   # get text child of xml element - returns empty string if elem is nil or
   # text child is empty.  trims leading and trailing whitespace
   def get_xml_text(elem)

--- a/hawk/app/models/primitive.rb
+++ b/hawk/app/models/primitive.rb
@@ -31,8 +31,17 @@ class Primitive < Template
   validate :validate_params
 
   def validate_params
+    required_params = []
+    res = Hash.from_xml(Util.get_meta_data(agent_name))
+    param_res = res["resource_agent"]["parameters"]["parameter"]
+    param_res.each do |items|
+      if items.key?("required") && items["required"] == "1"
+        required_params << items["name"]
+      end
+    end
+
     params.each do |param, value|
-      if value.blank?
+      if value.blank? && required_params.include?(param)
         errors.add(:base, "In Parameters, #{param}'s value is blank!")
       end
     end


### PR DESCRIPTION
In resource_agents, some boolean param's default value is chaotic,
there are "yes|No|no|1|0" available, 
these default value can not be shown on the attrlist, because thay are not "true|false".

I replaced above options to "true" or "false", and with #110, moved codes to util.rb

Regards,
xin