### PR TITLE
Commits set about constraint error show and crash

### DIFF
--- a/hawk/app/controllers/colocations_controller.rb
+++ b/hawk/app/controllers/colocations_controller.rb
@@ -25,30 +25,36 @@ class ColocationsController < ApplicationController
     end
   end
 
+  class CreateFailure < RuntimeError
+  end
+
   def create
     normalize_params! params[:colocation].permit!
     @title = _("Create Colocation")
 
     @colocation = Colocation.new params[:colocation].permit!
 
-    respond_to do |format|
-      if @colocation.save
-        post_process_for! @colocation
+    fail CreateFailure, @colocation.errors.full_messages.to_sentence unless @colocation.save
+    post_process_for! @colocation
 
-        format.html do
-          flash[:success] = _("Constraint created successfully")
-          redirect_to edit_cib_colocation_url(cib_id: @cib.id, id: @colocation.id)
-        end
-        format.json do
-          render json: @colocation, status: :created
-        end
-      else
-        format.html do
-          render action: "new"
-        end
-        format.json do
-          render json: @colocation.errors, status: :unprocessable_entity
-        end
+    respond_to do |format|
+      format.html do
+        flash[:success] = _("Constraint created successfully")
+        redirect_to edit_cib_colocation_url(cib_id: @cib.id, id: @colocation.id)
+      end
+      format.json do
+        render json: @colocation, status: :created
+      end
+    end
+
+  rescue CreateFailure => e
+    respond_to do |format|
+      format.html do
+        flash[:danger] = e.to_s
+        render action: "new"
+      end
+      format.json do
+        render json: @colocation.errors, status: :unprocessable_entity
       end
     end
   end

--- a/hawk/app/controllers/locations_controller.rb
+++ b/hawk/app/controllers/locations_controller.rb
@@ -48,6 +48,7 @@ class LocationsController < ApplicationController
         expressions: []
       )
     end
+    @location.rules = Util.map_value(@location.rules)
 
     respond_to do |format|
       if @location.save

--- a/hawk/app/lib/util.rb
+++ b/hawk/app/lib/util.rb
@@ -360,4 +360,25 @@ module Util
     elem ? (elem.text.strip || '') : ''
   end
   module_function :get_xml_text
+
+  # https://apidock.com/rails/v4.2.7/Hash/deep_symbolize_keys
+  def symbolize_rescursive(hash)
+    {}.tap do |h|
+      hash.each { |key, value| h[key.to_sym] = map_value(value) }
+    end
+  end
+  module_function :symbolize_rescursive
+
+  # https://apidock.com/rails/v4.2.7/Hash/deep_symbolize_keys
+  def map_value(thing)
+    case thing
+    when Hash
+      symbolize_rescursive(thing)
+    when Array
+      thing.map { |v| map_value(v) }
+    else
+      thing
+    end
+  end
+  module_function :map_value
 end

--- a/hawk/app/models/colocation.rb
+++ b/hawk/app/models/colocation.rb
@@ -92,6 +92,7 @@ class Colocation < Constraint
       # Have to clone out of @resources, else we've just got references
       # to elements of @resources inside collapsed, which causes @resources
       # to be modified, which we *really* don't want.
+      @resources = Util.map_value(@resources)
       collapsed = [ @resources.first.clone ]
       @resources.last(@resources.length - 1).each do |set|
         if collapsed.last[:sequential] == set[:sequential] &&

--- a/hawk/app/models/constraint.rb
+++ b/hawk/app/models/constraint.rb
@@ -11,7 +11,7 @@ class Constraint < Record
     # to validate a new record:
     # try making the shell form and running verify;commit in a temporary shadow cib in crm
     # if it fails, report errors
-    if record.new_record && current_cib.live?
+    if record.errors.blank? && record.new_record && current_cib.live?
       cli = record.shell_syntax
       _out, err, rc = Invoker.instance.no_log do |i|
         i.crm_configure ['cib new', cli, 'verify', 'commit'].join("\n")

--- a/hawk/app/models/resource.rb
+++ b/hawk/app/models/resource.rb
@@ -19,7 +19,7 @@ class Resource < Record
     # to validate a new record:
     # try making the shell form and running verify;commit in a temporary shadow cib in crm
     # if it fails, report errors
-    if record.new_record && current_cib.live?
+    if record.errors.blank? && record.new_record && current_cib.live?
       cli = record.shell_syntax
       _out, err, rc = Invoker.instance.no_log do |i|
         i.crm_configure ['cib new', cli, 'verify', 'commit'].join("\n")


### PR DESCRIPTION
1. Dev: Make sure no errors before crm configure verify 

    When adding resources or constraints, we use "crm configure" to verify commits;
Before that, we have already done some checks, such as id's presence and resources.length for colocation, it's better to make sure that these checks have passed successfully, and then, let "crm configure" to verify

    For example, when adding a primitive resource,
I forgot to input Resource ID, after submit,
errors list are "ID ID is required, ID Invalid, 2: ocf:Heartbeat:IPaddr2 invalid object id" ,
they are complaining the same thing:)
That's not necessary.