### PR TITLE
Dev: Strip redundant error messages

### DIFF
--- a/hawk/app/models/colocation.rb
+++ b/hawk/app/models/colocation.rb
@@ -7,7 +7,7 @@ class Colocation < Constraint
   attribute :resources, Array[Hash]
 
   validates :score,
-    presence: { message: _("Score is required") }
+    presence: { message: _("is required") }
 
   validate do |record|
     record.score.strip!
@@ -21,7 +21,7 @@ class Colocation < Constraint
       "-infinity"
     ].include? record.score.downcase
       unless record.score.match(/^-?[0-9]+$/)
-        errors.add :score, _("Invalid score value")
+        errors.add :score, _("value is invalid")
       end
     end
 

--- a/hawk/app/models/location.rb
+++ b/hawk/app/models/location.rb
@@ -7,10 +7,10 @@ class Location < Constraint
   attribute :discovery, String
 
   validates :resources,
-    presence: { message: _("No resource specified") }
+    presence: { message: _("not specified") }
 
   validates :rules,
-    presence: { message: _("No rules specified") }
+    presence: { message: _("not specified") }
 
   validate do |record|
     unless record.discovery.blank?

--- a/hawk/app/models/record.rb
+++ b/hawk/app/models/record.rb
@@ -7,8 +7,8 @@ class Record < Tableless
   attr_accessor :xml
 
   validates :id,
-    presence: { message: _("ID is required") },
-    format: { with: /\A[a-zA-Z0-9_.-]+\z/, message: _("Invalid ID") }
+    presence: { message: _("is required") },
+    format: { with: /\A[a-zA-Z0-9_.-]+\z/, message: _("is invalid") }
 
   class << self
     # Check whether anything with the given ID exists, or for a specific element


### PR DESCRIPTION
Error messages like "ID ID is required", "ID Invalid ID", "Score Score is required" and "Score Invalid score value" are redundant

It's better to make it clear

Regards,
xin 