### PR TITLE
Dev: Set target-role default value to Stopped

### DIFF
--- a/hawk/app/models/clone.rb
+++ b/hawk/app/models/clone.rb
@@ -78,7 +78,7 @@ class Clone < Resource
           },
           "target-role" => {
             type: "enum",
-            default: "Started",
+            default: "Stopped",
             values: ["Started", "Stopped", "Master"],
             longdesc: _("What state should the cluster attempt to keep this resource in?")
           },

--- a/hawk/app/models/group.rb
+++ b/hawk/app/models/group.rb
@@ -74,7 +74,7 @@ class Group < Resource
           },
           "target-role" => {
             type: "enum",
-            default: "Started",
+            default: "Stopped",
             values: [
               "Started",
               "Stopped",

--- a/hawk/app/models/master.rb
+++ b/hawk/app/models/master.rb
@@ -73,7 +73,7 @@ class Master < Resource
           },
           "target-role" => {
             type: "enum",
-            default: "Started",
+            default: "Stopped",
             values: [
               "Started",
               "Stopped",

--- a/hawk/app/models/template.rb
+++ b/hawk/app/models/template.rb
@@ -266,7 +266,7 @@ class Template < Resource
             },
             "target-role" => {
               type: "enum",
-              default: "Started",
+              default: "Stopped",
               values: ["Started", "Stopped", "Master"],
               longdesc: _("What state should the cluster attempt to keep this resource in?")
             },


### PR DESCRIPTION
I noticed that primitive/group/clone/master's default target-role on the page is "Stopped",
when I delete it, and then, re-add target-role, the default value changed as "Started",
it's better to be unified

regards,
xin