### PR TITLE
Dev: 0 instead of INFINITY means disabled for migration-threshold

### DIFF
--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -18,10 +18,6 @@ class CrmConfig < Tableless
       default: "false",
       longdesc: _("Resources in maintenance mode are not monitored by the cluster.")
     },
-    "interval-origin" => {
-      type: "integer",
-      default: "0"
-    },
     "migration-threshold" => {
       type: "integer",
       default: "0",
@@ -126,7 +122,8 @@ class CrmConfig < Tableless
     },
     "interval-origin" => {
       type: "string",
-      default: "0"
+      default: "",
+      longdesc: _("The start time of action interval. Follow the ISO8601 standard.")
     },
     "record-pending" => {
       type: "boolean",

--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -94,7 +94,8 @@ class CrmConfig < Tableless
     },
     "timeout" => {
       type: "string",
-      default: "20"
+      default: "20",
+      longdesc: _("How long to wait before declaring the action has failed.")
     },
     "requires" => {
       type: "enum",

--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -104,7 +104,8 @@ class CrmConfig < Tableless
     },
     "enabled" => {
       type: "boolean",
-      default: "true"
+      default: "true",
+      longdesc: _("If false, the operation is treated as if it does not exist.")
     },
     "role" => {
       type: "enum",

--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -25,7 +25,7 @@ class CrmConfig < Tableless
     "migration-threshold" => {
       type: "integer",
       default: "0",
-      longdesc: _("How many failures may occur for this resource on a node, before this node is marked ineligible to host this resource. A value of INFINITY indicates that this feature is disabled.")
+      longdesc: _("How many failures may occur for this resource on a node, before this node is marked ineligible to host this resource. A value of 0 indicates that this feature is disabled.")
     },
     "priority" => {
       type: "integer",

--- a/hawk/app/models/template.rb
+++ b/hawk/app/models/template.rb
@@ -241,7 +241,7 @@ class Template < Resource
             "migration-threshold" => {
               type: "integer",
               default: "0",
-              longdesc: _("How many failures may occur for this resource on a node, before this node is marked ineligible to host this resource. A value of INFINITY indicates that this feature is disabled.")
+              longdesc: _("How many failures may occur for this resource on a node, before this node is marked ineligible to host this resource. A value of 0 indicates that this feature is disabled.")
             },
             "priority" => {
               type: "integer",

--- a/hawk/app/models/template.rb
+++ b/hawk/app/models/template.rb
@@ -311,7 +311,7 @@ class Template < Resource
             },
             "timeout" => {
               type: "string",
-              default: "0",
+              default: "20",
               required: true,
               longdesc: _("How long to wait before declaring the action has failed.")
             },

--- a/hawk/app/models/template.rb
+++ b/hawk/app/models/template.rb
@@ -234,10 +234,6 @@ class Template < Resource
               default: "false",
               longdesc: _("Resources in maintenance mode are not monitored by the cluster.")
             },
-            "interval-origin" => {
-              type: "integer",
-              default: "0"
-            },
             "migration-threshold" => {
               type: "integer",
               default: "0",
@@ -364,7 +360,8 @@ class Template < Resource
             },
             "interval-origin" => {
               type: "string",
-              default: "0"
+              default: "",
+              longdesc: _("The start time of action interval. Follow the ISO8601 standard.")
             },
             "record-pending" => {
               type: "boolean",


### PR DESCRIPTION
http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html/Pacemaker_Explained/s-resource-options.html#_resource_meta_attributes
and in doc, INFINITY is the default value, 
in crmsh, set migration-threshold=3 by default,
I think both 0|3 are OK