### PR TITLE
Dev: Delete oplist key which named as "jQuery\d+"

### DIFF
--- a/hawk/app/assets/javascripts/module/oplist.js
+++ b/hawk/app/assets/javascripts/module/oplist.js
@@ -253,6 +253,11 @@
                                self.attr_mapping);
       }
 
+      $.each(attrmapping, function(k) {
+        if (k.match(/jQuery\d+/)) {
+          delete attrmapping[k];
+        }
+      });
       alist.data('attrlist-mapping', attrmapping);
       alist.attrList();
       modal.modal('show');


### PR DESCRIPTION
When adding new Operations in "Create Primitive", option named as "jQuery\d+" can be selected,
that make no-sense.

Regards,
xin

BTW, I don't known how this key created in selected oplist, it's better exclude this key when created than
deleting it later:)