### PR TITLE
Dev: Use "overflow: inherit" to avoid dropdown creates scrollbar

### DIFF
--- a/hawk/app/assets/stylesheets/shared/_form.scss
+++ b/hawk/app/assets/stylesheets/shared/_form.scss
@@ -168,5 +168,5 @@ fieldset[disabled], fieldset[disabled]:active, fieldset[disabled]:focus,
 }
 
 .tab-pane .form-group {
-  overflow: auto;
+  overflow: inherit;
 }


### PR DESCRIPTION
When adding Score in location, dropdown will create scrollbar on right.

According to https://stackoverflow.com/questions/18918010/bootstrap-dropdown-creates-scrollbar-to-parent-div

use inherit instead of auto can resolve this problem

hope this no any side effect:)
Regards,
xin