### PR TITLE
Dev: disabled click when wizard apply successfully

### DIFF
--- a/hawk/app/assets/javascripts/module/wizards.js
+++ b/hawk/app/assets/javascripts/module/wizards.js
@@ -79,6 +79,7 @@ $(function() {
         content.html('<pre>' + $('<div/>').text(data.output).html() + '</pre>');
       });
     }
+    vform.find(".submit").addClass("disabled").bind("click", false);
     vform.find(".actions .list-group-item").removeClass("disabled").addClass("list-group-item-success");
     vform.find(".notifications").html('<div class="alert alert-success">' + __("Changes applied successfully.") + '</div>');
   });


### PR DESCRIPTION
In wizard, when Apply successfully, we no need this btn enabled and clickable,
click "Apply" twice after successfully apply will cause error because use the same id,
this can make user confused

Regards,
xin