### PR TITLE
Dev: Do not allow dots in id to prevent routing issues

### DIFF
--- a/hawk/app/models/record.rb
+++ b/hawk/app/models/record.rb
@@ -8,7 +8,7 @@ class Record < Tableless
 
   validates :id,
     presence: { message: _("ID is required") },
-    format: { with: /\A[a-zA-Z0-9_.-]+\z/, message: _("Invalid ID") }
+    format: { with: /\A[a-zA-Z0-9_-]+\z/, message: _("Invalid ID") }
 
   class << self
     # Check whether anything with the given ID exists, or for a specific element


### PR DESCRIPTION
Related to https://github.com/ClusterLabs/hawk/issues/151

We should not allow dots in the id section and i think the dot in the regex validation was there by accident since it is now allowed in the recipient model aswell. If there is a good reason to have dots in the ID there is a way to make it work in rails, but i think it's more convenient to just not allow such things :) 