### PR TITLE
Api: return nil if elem is nil(fate#323437)

### DIFF
--- a/hawk/app/lib/cibtools.rb
+++ b/hawk/app/lib/cibtools.rb
@@ -10,6 +10,7 @@ module CibTools
 
   # Roughly equivalent to crm_element_value() in Pacemaker
   def get_xml_attr(elem, name, default = nil)
+    return nil if elem.nil?
     Util.unstring(elem.attributes[name], default)
   end
   module_function :get_xml_attr


### PR DESCRIPTION
     in some case, param in determine_online_status_fencing is nil,
     this will cause NoMethodError