### PR TITLE
Api: change to_hash function more dynamic(fate#323437)

### DIFF
--- a/hawk/app/models/api/v1/cluster.rb
+++ b/hawk/app/models/api/v1/cluster.rb
@@ -38,17 +38,8 @@ module Api
       end
 
        # Implicite conversion to hash
-       def to_hash
-        {
-          cluster_infrastructure: cluster[:cluster_infrastructure],
-          dc_version: cluster[:dc_version],
-          stonith_enabled: cluster[:stonith_enabled],
-          symmetric_cluster: cluster[:symmetric_cluster],
-          no_quorum_policy: cluster[:no_quorum_policy],
-          epoch: cluster[:epoch],
-          dc: cluster[:dc],
-          host: cluster[:host]
-        }
+      def to_hash
+        cluster
       end
 
     end


### PR DESCRIPTION
Why we had hard code here? The property of cluster may be changed
e.g. append a property like "maintenance_mode=false", this cluster property will not be shown

Or, do these hard code property planned to be a "base" info of cluster? 
     And other properties as "advance" info?
     I think that we should show all of them in api, then classify/sort them in client code