### PR TITLE
Api: get right status when resource is started(fate#323437)

### DIFF
--- a/hawk/app/models/api/v1/resource.rb
+++ b/hawk/app/models/api/v1/resource.rb
@@ -29,7 +29,7 @@ module Api
       def state
         state = :stopped
         @instances.each do |instance|
-          state = :running if state == :stopped && instance[:state] == :running
+          state = :running if state == :stopped && instance[:state] == :started
           state = :failed if instance[:state] == :failed
         end
         state


### PR DESCRIPTION
The value of instance[:state] include ":started" and ":stopped", instead of ":running"