### PR TITLE
Api: primitive resource's type should always be primitive(fate#323437)

### DIFF
--- a/hawk/app/models/api/v1/resource.rb
+++ b/hawk/app/models/api/v1/resource.rb
@@ -20,8 +20,6 @@ module Api
       end
 
       def type
-        return :clone if @config.parent.name == "clone"
-        return :multistate if @config.parent.name == "master"
         :primitive
       end
 


### PR DESCRIPTION
The group/clone/ms resource includes one or more primitive resources;
Even belong to a group/clone/ms, a primitive resource's type should be primitive.

BTW, I think it will be convenient to provide group/clone/ms perspective to look at which primitive resources included, through new rails route or related parameters after "/api/v1/resources"