### PR TITLE
Handle new daemon names in hawk

### DIFF
--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -57,7 +57,10 @@ class CrmConfig < Tableless
             [
               "pengine",
               "crmd",
-              "cib"
+              "cib",
+              "pacemaker-schedulerd",
+              "pacemaker-controld",
+              "pacemaker-based"
             ].each do |cmd|
               [
                 "/usr/libexec/pacemaker/#{cmd}",

--- a/tools/hawk_invoke.c
+++ b/tools/hawk_invoke.c
@@ -73,6 +73,8 @@ static struct cmd_map commands[] = {
 	{"pengine",        LIBDIR"/pacemaker/pengine"},
 	{"hb_report",      SBINDIR"/hb_report"},
 	{"booth",          SBINDIR"/booth"},
+	{"pacemaker-schedulerd", LIBDIR"/pacemaker/pacemaker-schedulerd"},
+	{"pacemaker-controld", LIBDIR"/pacemaker/pacemaker-controld"},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
These should be the only changes needed to make hawk able to handle the new daemon names, and I don't think any critical functionality is affected by not having the changes.