### PR TITLE
Work around the removal of Dir::Tmpname#make_tmpname (bsc#1162221)

### DIFF
--- a/hawk/app/controllers/graphs_controller.rb
+++ b/hawk/app/controllers/graphs_controller.rb
@@ -10,7 +10,7 @@ class GraphsController < ApplicationController
     respond_to do |format|
       format.html
       format.svg do
-        path = Pathname.new("#{Rails.root}/tmp").join(Dir::Tmpname.make_tmpname(["graph", ".svg"], nil))
+        path = Pathname.new("#{Rails.root}/tmp").join(make_tmpname("graph", ".svg"))
         begin
           _out, err, rc = Invoker.instance.no_log do |invoker|
             invoker.crm("configure", "graph", "dot", path.to_s, "svg")
@@ -51,5 +51,13 @@ END
 
   def set_cib
     @cib = current_cib
+  end
+
+  private
+
+  def make_tmpname(prefix, suffix)
+    timestamp = Time.now.strftime("%Y%m%d")
+    random = rand(0x100000000).to_s(36)
+    "#{prefix}#{timestamp}-#{$$}-#{random}#{suffix}"
   end
 end


### PR DESCRIPTION
A commit [0] in ruby 2.5 removed the Dir::Tmpname#make_tmpname method. This patch works around that removal by implementing a minimalistic version of that method that conforms to the former format of generated filenames.

Fixes bsc#1162221.

[0] https://github.com/ruby/ruby/commit/25d56ea7b7b52dc81af30c92a9a0e2d2dab6ff27