### PR TITLE
Fix omission of built-in stonith attributes

### DIFF
--- a/hawk/app/controllers/agents_controller.rb
+++ b/hawk/app/controllers/agents_controller.rb
@@ -22,7 +22,7 @@ class AgentsController < ApplicationController
     else
       @name = params[:id]
     end
-    @agent = Hash.from_xml(Util.get_meta_data(@name))
+    @agent = Util.get_metadata_hash(@name)
 
     if @agent
       respond_to do |format|

--- a/hawk/app/models/crm_config.rb
+++ b/hawk/app/models/crm_config.rb
@@ -62,55 +62,46 @@ class CrmConfig < Tableless
               "pacemaker-controld",
               "pacemaker-based"
             ].each do |cmd|
-              [
-                "/usr/libexec/pacemaker/#{cmd}",
-                "/usr/lib64/pacemaker/#{cmd}",
-                "/usr/lib/pacemaker/#{cmd}",
-                "/usr/lib64/heartbeat/#{cmd}",
-                "/usr/lib/heartbeat/#{cmd}"
-              ].each do |path|
-                next unless File.executable? path
+              path = "#{Rails.configuration.x.crm_daemon_dir}/#{cmd}"
+              next unless File.executable? path
 
-                REXML::Document.new(%x[#{path} metadata 2>/dev/null]).tap do |xml|
-                  return unless xml.root
+              REXML::Document.new(%x[#{path} metadata 2>/dev/null]).tap do |xml|
+                return unless xml.root
 
-                  xml.elements.each("//parameter") do |param|
-                    name = param.attributes["name"]
-                    content = param.elements["content"]
-                    shortdesc = param.elements["shortdesc[@lang=\"#{I18n.locale.to_s.gsub("-", "_")}\"]|shortdesc[@lang=\"en\"]"].text || ""
-                    longdesc  = param.elements["longdesc[@lang=\"#{I18n.locale.to_s.gsub("-", "_")}\"]|longdesc[@lang=\"en\"]"].text || ""
+                xml.elements.each("//parameter") do |param|
+                  name = param.attributes["name"]
+                  content = param.elements["content"]
+                  shortdesc = param.elements["shortdesc[@lang=\"#{I18n.locale.to_s.gsub("-", "_")}\"]|shortdesc[@lang=\"en\"]"].text || ""
+                  longdesc  = param.elements["longdesc[@lang=\"#{I18n.locale.to_s.gsub("-", "_")}\"]|longdesc[@lang=\"en\"]"].text || ""
 
-                    type = content.attributes["type"]
-                    default = content.attributes["default"]
+                  type = content.attributes["type"]
+                  default = content.attributes["default"]
 
-                    advanced = shortdesc.match(/advanced use only/i) || longdesc.match(/advanced use only/i)
+                  advanced = shortdesc.match(/advanced use only/i) || longdesc.match(/advanced use only/i)
 
-                    crm_config[name] = {
-                      type: content.attributes["type"],
-                      readonly: false,
-                      shortdesc: shortdesc,
-                      longdesc: longdesc,
-                      advanced: advanced ? true : false,
-                      default: default
-                    }
+                  crm_config[name] = {
+                    type: content.attributes["type"],
+                    readonly: false,
+                    shortdesc: shortdesc,
+                    longdesc: longdesc,
+                    advanced: advanced ? true : false,
+                    default: default
+                  }
 
-                    if type == "enum"
-                      match = longdesc.match(/Allowed values:(.*)/i)
+                  if type == "enum"
+                    match = longdesc.match(/Allowed values:(.*)/i)
 
-                      if match
-                        values = match[1].split(",").map do |value|
-                          value.strip
-                        end.reject do |value|
-                          value.empty?
-                        end
-
-                        crm_config[name][:values] = values unless values.empty?
+                    if match
+                      values = match[1].split(",").map do |value|
+                        value.strip
+                      end.reject do |value|
+                        value.empty?
                       end
+
+                      crm_config[name][:values] = values unless values.empty?
                     end
                   end
                 end
-
-                break
               end
             end
 

--- a/hawk/app/models/primitive.rb
+++ b/hawk/app/models/primitive.rb
@@ -32,7 +32,7 @@ class Primitive < Template
 
   def validate_params
     required_params = []
-    res = Hash.from_xml(Util.get_meta_data(agent_name))
+    res = Util.get_metadata_hash(agent_name)
     param_res = res["resource_agent"]["parameters"]["parameter"]
     if param_res
       param_res.each do |items|

--- a/hawk/config/application.rb
+++ b/hawk/config/application.rb
@@ -46,5 +46,24 @@ module Hawk
 
     config.x.hawk_is_sles = system("cat /etc/os-release | grep 'ID=.*sles' >/dev/null 2>&1")
 
+    def lookup_daemon_dir
+      [
+        "/usr/libexec/pacemaker",
+        "/usr/lib64/pacemaker",
+        "/usr/lib/pacemaker",
+        "/usr/lib64/heartbeat",
+        "/usr/lib/heartbeat"
+      ].each do |dir|
+        [
+          "crmd",
+          "pacemaker-controld",
+        ].each do |cmd|
+          return dir if File.executable? "#{dir}/#{cmd}"
+        end
+      end
+      "/usr/libexec/pacemaker"
+    end
+
+    config.x.crm_daemon_dir = lookup_daemon_dir
   end
 end


### PR DESCRIPTION
Pacemaker implements special instance attributes that can be set for any stonith resource, for example, `pcmk_host_list`. Hawk uses `crm_resource --show-metadata <ra>` to obtain parameters valid for a specific resource agent but output from this command does not list these common stonith attributes. They can be however obtained separately by invoking `pacemaker-fenced metadata`.

This pull request updates the logic that queries agent's metadata to additionally invoke the latter command (if the resource has the stonith class) and use its output to complete agent's parameters.