### PR TITLE
Work around the removal of Dir::Tmpname#make_tmpname (bsc#1162221)

### DIFF
--- a/hawk/app/controllers/graphs_controller.rb
+++ b/hawk/app/controllers/graphs_controller.rb
@@ -10,7 +10,7 @@ class GraphsController < ApplicationController
     respond_to do |format|
       format.html
       format.svg do
-        path = Pathname.new("#{Rails.root}/tmp").join(Dir::Tmpname.make_tmpname(["graph", ".svg"], nil))
+        path = Pathname.new("#{Rails.root}/tmp").join(make_tmpname("graph", ".svg"))
         begin
           _out, err, rc = Invoker.instance.no_log do |invoker|
             invoker.crm("configure", "graph", "dot", path.to_s, "svg")
@@ -51,5 +51,13 @@ END
 
   def set_cib
     @cib = current_cib
+  end
+
+  private
+
+  def make_tmpname(prefix, suffix)
+    timestamp = Time.now.strftime("%Y%m%d")
+    random = rand(0x100000000).to_s(36)
+    "#{prefix}#{timestamp}-#{$$}-#{random}#{suffix}"
   end
 end


### PR DESCRIPTION
# Description:

Backport from Fix from master (4d08c0c077c5d94e5bf37ae7adb0826dc015c973) Work around the removal of Dir::Tmpname#make_tmpname (bsc#1162221).


@diegoakechi this is the logical backport for SLE15.

I honestly found confusing the how we menage the releases.

Since `stable` is SLE15 but we have a sle15-sp1 branch. ( we have space to improve :grin: )

The question is now if we should also backport this to sles15-sp1
