### PR TITLE
SLE12: Fix bsc#1163381

### DIFF
--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -954,7 +954,7 @@ class Cib
           end
 
           # check for guest nodes
-          if state == :master || state == :started
+          if lrm_resource.attributes['container'].nil? && (state == :master || state == :started)
             on_node = op.attributes['on_node']
             @nodes.select { |n| n[:uname] == rsc_id }.each do |guest|
               guest[:host] = node[:uname]


### PR DESCRIPTION
Hawk2 returns "Low level server error occurred" after authentication if a resource has the same name as a node"


# status:

on old right now for waiting other SR