### PR TITLE
SLE15: Fix bsc#1163381

### DIFF
--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -983,7 +983,7 @@ class Cib
           state = CibTools.op_rc_to_state operation, rc_code, state
 
           # check for guest nodes
-          if !op.attributes['on_node'].nil? && [:master, :started].include?(state)
+          if !op.attributes['on_node'].nil? && [:master, :started].include?(state) && lrm_resource.attributes['container'].nil? 
             @nodes.select { |n| n[:uname] == rsc_id }.each do |guest|
               guest[:host] = node[:uname]
               guest[:remote] = true


### PR DESCRIPTION
Hawk2 returns "Low level server error occurred" after authentication if a resource has the same name as a node"