### PR TITLE
Fix application_controller invalid system call

### DIFF
--- a/hawk/app/controllers/application_controller.rb
+++ b/hawk/app/controllers/application_controller.rb
@@ -190,7 +190,7 @@ class ApplicationController < ActionController::Base
     user = cookies['hawk_remember_me_id']
     return if user.nil?
     # read from attrd
-    values = system(attrd_updater, "-R", "-Q","-A", "-n", "hawk_session_#{user}").scan(/value=\"(.*)\"/).flatten(1)
+    values = %x[/usr/sbin/attrd_updater -R -Q -A -n "hawk_session_#{user}"].scan(/value=\"(.*)\"/).flatten(1)
     user if values.include? cookies['hawk_remember_me_key']
   end
 


### PR DESCRIPTION
This partially reverts 2fe6369e6f70a0fe2f9d8ab884ae6bb4606f6f39

Otherwise, hawk crashes with 

 bundle[14597]: #<NameError: undefined local variable or method `attrd_updater' for 
