### PR TITLE
Use VERSION instead of VERSION_ID

### DIFF
--- a/e2e_test/README.md
+++ b/e2e_test/README.md
@@ -20,7 +20,7 @@ See https://github.com/SUSE/pacemaker-deploy  for deploying hawk
 `docker build . -t hawk_test `
 
 2) Run the tests with:
-``` docker run --ipc=host hawk_test -H 10.162.32.175 -S 10.162.29.122 -s linux --xvfb ```
+``` docker run --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY hawk_test -H 10.162.32.175 -S 10.162.29.122 -s linux --xvfb ```
 
 Notes:
   - You may want to add `--net=host` if you have problems with DNS resolution.

--- a/e2e_test/hawk_test.py
+++ b/e2e_test/hawk_test.py
@@ -75,7 +75,7 @@ def main():
     ssh = HawkTestSSH(args.host, args.secret)
 
     # Get version from /etc/os-release
-    test_version = ssh.ssh.exec_command("grep VERSION_ID /etc/os-release")[1].read().decode().strip().split("=")[1][1:-1]
+    test_version = ssh.ssh.exec_command("grep ^VERSION= /etc/os-release")[1].read().decode().strip().split("=")[1].strip('"')
 
     # Create driver instance
     browser = HawkTestDriver(addr=args.host, port=args.port,


### PR DESCRIPTION
We must use `VERSION` (which is a string like 12-SPx) instead of `VERSION_ID` which is a float.  We use the former in the code to test versions.