### PR TITLE
e2e_test: Drop timeout and look for report instead

### DIFF
--- a/e2e_test/hawk_test_driver.py
+++ b/e2e_test/hawk_test_driver.py
@@ -381,11 +381,8 @@ class HawkTestDriver:
         if self.find_element(By.XPATH, Xpath.GENERATE_REPORT):
             self.check_and_click_by_xpath("Could not find button for Generate report",
                                           [Xpath.GENERATE_REPORT])
-            # Need to wait here because there are 2 success notices being shown in the GUI: on
-            # clicking the Generate report button and on completing the generation. This next
-            # sleep() waits for the first notice to disappear before waiting for the second one
-            time.sleep(BIG_TIMEOUT)
-        if self.verify_success():
+            # Look for actual report
+            self.find_element(By.LINK_TEXT, "hawk")
             print("INFO: successfully generated report")
             return True
         print("ERROR: failed to generate report")


### PR DESCRIPTION
The report generation usually fails over my VPN and times out.

Better drop the timeout and check for the link to the report instead.

Tested with the latest MU's on 12-SP{3,4,5}, 15-GA & 15-SP{1,2}