### PR TITLE
Add automatic testing for continious developmend

### DIFF
--- a/.github/workflows/test-hawk.yaml
+++ b/.github/workflows/test-hawk.yaml
@@ -1,0 +1,47 @@
+name: e2e_test for hawk
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  IP_NODE1: 172.17.0.2
+  IP_NODE2: 172.17.0.3
+
+jobs:
+  functional_test_crm_report_bugs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Start cluster nodes in containers
+        run: |
+          docker run -d --privileged -h node1 --name node1 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} ghcr.io/aleksei-burlakov/hawk-node
+          docker run -d --privileged -h node2 --name node2 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} ghcr.io/aleksei-burlakov/hawk-node
+      - name: Copy hawk to the nodes
+        run: |
+          cd ..
+          docker cp hawk node1:/
+          docker cp hawk node2:/
+      - name: Compile hawk in the nodes
+        run: |
+          docker exec -i node1 bash -c "cd hawk && make"
+          docker exec -i node2 bash -c "cd hawk && make"
+      - name: Install hawk in the nodes
+        run: |
+          docker exec -i node1 bash -c "cd hawk && make install && cp scripts/sysconfig.hawk /etc/sysconfig/hawk"
+          docker exec -i node2 bash -c "cd hawk && make install && cp scripts/sysconfig.hawk /etc/sysconfig/hawk"
+      - name: Initialize container on the node1
+        run: docker exec node1 crm cluster init -u -n cluster1 -y
+      - name: Join node2 to the cluster
+        run: docker exec node2 crm cluster join -c node1 -y
+      - name: Create a stonith-sbd device
+        run: |
+          docker exec node1 crm configure primitive stonith-sbd stonith:external/ssh params hostlist="node1 node2"
+          docker exec node1 crm conf property stonith-enabled=true
+          docker exec node1 crm conf property have-watchdog=true
+      - name: Run the functional test
+        run: docker run ghcr.io/aleksei-burlakov/hawk-examiner -H ${IP_NODE1} -S ${IP_NODE2} -s linux --xvfb

--- a/scripts/sysconfig.hawk
+++ b/scripts/sysconfig.hawk
@@ -1,0 +1,59 @@
+## Path:            Cluster/Hawk
+## Description:     Mode of operation
+## Type:            string(production,development,test)
+## Default:         production
+## ServiceRestart:  hawk
+# Hawk can run in production, development or test mode. Normally, this
+# determines which database is used, but it may also have other
+# implications.
+HAWK_ENV="production"
+
+## Path:            Cluster/Hawk
+## Description:     Maximum number of threads
+## Type:            integer
+## Default:         1
+## ServiceRestart:  hawk
+# Sets the maximum number of threads used by the web server.
+HAWK_THREADS="16"
+
+## Path:            Cluster/Hawk
+## Description:     Maximum number of worker processes
+## Type:            integer
+## Default:         2
+## ServiceRestart:  hawk
+# Sets the maximum number of separate worker processes spawned by the
+# web server.
+HAWK_WORKERS="1"
+
+## Path:            Cluster/Hawk
+## Description:     Listen address
+## Type:            ip
+## Default:         0.0.0.0
+## ServiceRestart:  hawk
+# Network address which Hawk listens to for connections.
+HAWK_LISTEN="0.0.0.0"
+
+## Path:            Cluster/Hawk
+## Description:     Port
+## Type:            integer(0:65565)
+## Default:         7630
+## ServiceRestart:  hawk
+# Port which Hawk listens to.
+HAWK_PORT="7630"
+
+## Path:            Cluster/Hawk
+## Description:     SSL key used by the web server
+## Type:            string
+## Default:         /etc/hawk/hawk.key
+## ServiceRestart:  hawk
+# Configures an SSL key that the Hawk web server presents.
+HAWK_KEY="/etc/hawk/hawk.key"
+
+## Path:            Cluster/Hawk
+## Description:     SSL certificate used by the web server
+## Type:            string
+## Default:         /etc/hawk/hawk.pem
+## ServiceRestart:  hawk
+# Configures an SSL certificate that the Hawk web server presents.
+HAWK_CERT="/etc/hawk/hawk.pem"
+


### PR DESCRIPTION
There is introduced a cd by means of github actions. It creates a basic 2-nodes ha cluster with a `stonith/ssh` resource and runs the `e2e_test` against the cluster. 
Q: Why are the containers started not as 
```
    container:
      image: ghcr.io/aleksei-burlakov/hawk-node:latest
```
but rather `docker run` ?
A: Because it's the only way to start them with the `--privileged` flag.
Q: Why not use k8s/k3s/helm charts, bash/python/whatsoever scripts to deploy the ha-cluster?
A: Yaml is already good enough.