### PR TITLE
Set HttpOnly by HAWK_COOKIE_HTTP_ONLY=true

### DIFF
--- a/hawk/app/lib/hawk/secure_cookies.rb
+++ b/hawk/app/lib/hawk/secure_cookies.rb
@@ -17,7 +17,8 @@ module Hawk
           next if cookie.blank?
           next if cookie =~ /;\s*secure/i
 
-          cookie << '; Secure ; HttpOnly'
+          cookie << '; Secure'
+          cookie << '; HttpOnly' if ENV['HAWK_COOKIE_HTTP_ONLY'] == 'true'
         end
 
         headers['Set-Cookie'] = cookies.join(COOKIE_SEPARATOR)


### PR DESCRIPTION
The flag HttpOnly was unconditional. It was set fot all cookies.
This commit gives you a choice. To set the HttpOnly flag you
need to pass the environment variable `HAWK_COOKIE_HTTP_ONLY=true`.
The simplest way to do it is to add it to the /etc/sysconfig/hawk file,
for example
```
$ echo "HAWK_COOKIE_HTTP_ONLY=true" >> /etc/sysconfig/hawk
$ systemctl restart hawk-backend
```