### PR TITLE
Improve handling of unmatched paths (bsc#1199258)

### DIFF
--- a/hawk/app/controllers/errors_controller.rb
+++ b/hawk/app/controllers/errors_controller.rb
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 SUSE LLC
+# See COPYING for license.
+
+class ErrorsController < ActionController::Base
+  protect_from_forgery with: :null_session
+
+  def not_found
+    respond_to do |format|
+      format.html do
+        render :file => "#{Rails.root}/public/404.html", :layout => false, :status => :not_found
+      end
+      format.any do
+        head :not_found
+      end
+    end
+  end
+end

--- a/hawk/config/routes.rb
+++ b/hawk/config/routes.rb
@@ -192,6 +192,6 @@ Rails.application.routes.draw do
   end
 
   if Rails.env.production?
-    get '*path' => redirect('/404.html') # if nothing else matches
+    match '*path' => 'errors#not_found', via: :all # if nothing else matches
   end
 end


### PR DESCRIPTION
* Extend handling of unmatched paths to all HTTP request types, not only GET.
* When processing an unmatched URL, avoid redirecting to the 404 error page via the HTTP 301 status code but instead directly return the page using code 404.