### PR TITLE
Minor enhancements to e2e_test

### DIFF
--- a/e2e_test/Dockerfile
+++ b/e2e_test/Dockerfile
@@ -2,7 +2,7 @@
 #!BuildTag: hawk_test
 # Use the repositories defined in OBS for installing packages
 #!UseOBSRepositories
-FROM	opensuse/leap:15.3
+FROM	registry.opensuse.org/opensuse/leap:15.4
 
 RUN	zypper -n install -y --no-recommends \
 		MozillaFirefox \
@@ -23,7 +23,7 @@ RUN	zypper -n install -y --no-recommends \
 		tar \
 		wget && \
 	zypper -n clean -a && \
-	wget -O- https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz | tar zxf - -C /usr/local/bin/
+	wget -O- https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz | tar zxf - -C /usr/local/bin/
 
 RUN	chmod +x /usr/local/bin/*
 

--- a/e2e_test/hawk_test_driver.py
+++ b/e2e_test/hawk_test_driver.py
@@ -71,7 +71,7 @@ class Xpath:
 
 
 class HawkTestDriver:
-    def __init__(self, addr='localhost', port='7630', browser='firefox', headless=False, version='12-SP2'):
+    def __init__(self, addr='localhost', port='7630', browser='firefox', headless=False, version='15-SP5'):
         self.addr = addr
         self.port = port
         self.driver = None
@@ -327,12 +327,11 @@ class HawkTestDriver:
         print("TEST: test_remove_cluster")
         self.click_on('Dashboard')
         self.check_and_click_by_xpath("Click on Dashboard", [Xpath.HREF_DASHBOARD])
-        if Version(self.test_version) >= Version('12-SP3'):
-            elem = self.find_element(By.PARTIAL_LINK_TEXT, cluster)
-            if not elem:
-                print(f"ERROR: Couldn't find cluster [{cluster}]. Cannot remove")
-                return False
-            elem.click()
+        elem = self.find_element(By.PARTIAL_LINK_TEXT, cluster)
+        if not elem:
+            print(f"ERROR: Couldn't find cluster [{cluster}]. Cannot remove")
+            return False
+        elem.click()
         time.sleep(BIG_TIMEOUT)
         elem = self.find_element(By.CLASS_NAME, 'close')
         if not elem:
@@ -357,13 +356,6 @@ class HawkTestDriver:
         if self.verify_success():
             print(f"INFO: Successfully removed cluster: [{cluster}]")
             return True
-        # HAWK2 version in 12-SP2 doesn't provide AJAX feedback for removal of cluster
-        if Version(self.test_version) < Version('12-SP3'):
-            self.click_on('Dashboard')
-            elem = self.find_element(By.PARTIAL_LINK_TEXT, cluster)
-            if not elem:
-                print(f"INFO: Successfully removed cluster: [{cluster}]")
-                return True
         print(f"ERROR: Could not remove cluster [{cluster}]")
         return False
 
@@ -551,10 +543,6 @@ class HawkTestDriver:
             Xpath.HREF_CONSTRAINTS, Xpath.HREF_NODES, Xpath.HREF_TAGS,
             Xpath.HREF_ALERTS, Xpath.HREF_FENCING
         ]
-
-        # HAWK version below 12-SP3 does not provide link to fencing
-        if Version(self.test_version) < Version("12-SP3"):
-            click_list.remove(Xpath.HREF_FENCING)
 
         self.check_and_click_by_xpath("while checking around edit configuration", click_list)
         return self.test_status


### PR DESCRIPTION
Minor enhancements to e2e_test:

- Use f-strings
- Drop <12-SP3 test code
- Update geckodriver
- Specify openSUSE registry in Dockerfile

These changes were already tested in all supported SLES versions in openQA / HA Incidents.