### PR TITLE
Disable autocomplete in the authentication password field

### DIFF
--- a/hawk/app/views/sessions/new.html.erb
+++ b/hawk/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @session, url: signin_path, simple: true, bootstrap: true do |main_form| %>
   <%= main_form.text_field :username, placeholder: _("Username"), label: { class: 'sr-only' } %>
-  <%= main_form.password_field :password, placeholder: _("Password"), label: { class: 'sr-only' } %>
+  <%= main_form.password_field :password, placeholder: _("Password"), label: { class: 'sr-only' }, :autocomplete => 'off' %>
   <%= main_form.submit _("Login"), class: "btn btn-primary btn-block" %>
 <% end %>


### PR DESCRIPTION
It tells the browser not to autocomplete the password textbox.