### PR TITLE
Enable ACL

### DIFF
--- a/hawk/app/controllers/sessions_controller.rb
+++ b/hawk/app/controllers/sessions_controller.rb
@@ -27,6 +27,7 @@ class SessionsController < ApplicationController
       if @session.valid?
         reset_session
         session[:username] = @session.username
+        session[:password] = @session.password
 
         # generate random value, store in attrd_updater (1024 Bits)
         value = SecureRandom.hex(128)
@@ -66,6 +67,7 @@ class SessionsController < ApplicationController
     cookies.delete :hawk_remember_me_id
     cookies.delete :hawk_remember_me_key
     session[:username] = nil
+    session[:password] = nil
     reset_session
 
     respond_to do |format|

--- a/hawk/app/lib/invoker.rb
+++ b/hawk/app/lib/invoker.rb
@@ -27,7 +27,7 @@ class Invoker
   # cleaned up further)
   # Returns [out, err, exitstatus]
   def run(*cmd)
-    out, err, status = Util.capture3(*cmd)
+    out, err, status = Util.run_as(current_user, current_pass, *cmd)
     [out, fudge_error(status.exitstatus, err), status.exitstatus]
   end
 
@@ -73,7 +73,7 @@ class Invoker
   # Invoke cibadmin with command line arguments.  Returns stdout as string,
   # Raises NotFoundError, SecurityError or RuntimeError on failure.
   def cibadmin(*cmd)
-    out, err, status = Util.capture3('cibadmin', *cmd)
+    out, err, status = Util.run_as(current_user, current_pass, 'cibadmin', *cmd)
     case status.exitstatus
     when 0
       return out
@@ -105,7 +105,7 @@ class Invoker
 
   # Used by the simulator
   def crm_simulate(*cmd)
-    Util.capture3('crm_simulate', *cmd)
+    Util.run_as(current_user, current_pass, 'crm_simulate', *cmd)
   end
 
   private
@@ -132,7 +132,7 @@ class Invoker
     end
     cmd << { stdin_data: input }
 
-    out, err, status = Util.capture3('crm', *cmd)
+    out, err, status = Util.run_as(current_user, current_pass, 'crm', *cmd)
     [out, fudge_error(status.exitstatus, err), status.exitstatus]
   end
 
@@ -152,5 +152,9 @@ class Invoker
 
   def current_user
     Thread.current[:current_user].call
+  end
+
+  def current_pass
+    Thread.current[:current_pass].call
   end
 end

--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -483,7 +483,7 @@ class Cib
     error(msg, :warning, additions)
   end
 
-  def initialize(id, user, use_file = false, stonithwarning = false)
+  def initialize(id, user, pass, use_file = false, stonithwarning = false)
     Rails.logger.debug "Cib.initialize #{id}, #{user}, #{use_file}"
 
     if use_file
@@ -511,7 +511,7 @@ class Cib
         init_offline_cluster id, user, use_file
         return
       end
-      out, err, status = Util.capture3('cibadmin', '-Ql')
+      out, err, status = Util.run_as(user, pass, 'cibadmin', '-Ql')
       case status.exitstatus
       when 0
         @xml = REXML::Document.new(out)

--- a/hawk/app/views/shared/_flash.html.erb
+++ b/hawk/app/views/shared/_flash.html.erb
@@ -9,7 +9,7 @@
           <%= _("Close") %>
         </span>
       </button>
-      <%= simple_format message %>
+      <%= simple_format message, {}, sanitize: false %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Basically we partitially revert 793b120cad
and improve the hawk_invoke so that it works as non-root.

Like in 793b120cad we do ` $ su -c <user>`, but instead of running as `root` we do it under `hacluster` (the hawk service is running by default under `hacluster`). And doing `hacluster$ su -c <user>` (under hacluster) requires the password of the `<user>` , so we store it in the `session` variable.