### PR TITLE
Fix mime type issue in MS windows

### DIFF
--- a/hawk/app/models/report.rb
+++ b/hawk/app/models/report.rb
@@ -279,6 +279,11 @@ class Report
     attribute :upload, ActionDispatch::Http::UploadedFile
 
     validate do |record|
+      # Windows doens't understand bzip2 and sends them as octet-stream,
+      # so let's make an exception for bzip2 and let them be octet-stream.
+      if record.upload.content_type == "application/octet-stream"
+          next if record.upload.original_filename =~ /^[a-zA-Z0-9_-]+\.tar\.bz2\z/
+      end
       unless ["application/gzip",
               "application/x-gzip",
               "application/x-bzip",


### PR DESCRIPTION
This change should accompish the commits a4969be6 and 6544880e. Basically we make an exception for bzip2 files, in a way that they may come as octet stream.