### PR TITLE
Enforse CSRF in errors_controller.rb

### DIFF
--- a/hawk/app/controllers/errors_controller.rb
+++ b/hawk/app/controllers/errors_controller.rb
@@ -2,7 +2,7 @@
 # See COPYING for license.
 
 class ErrorsController < ActionController::Base
-  protect_from_forgery with: :null_session
+  protect_from_forgery with: :exception
 
   def not_found
     respond_to do |format|


### PR DESCRIPTION
by changing the `protect_from_forgery` action to `:exception`