### PR TITLE
Enable HttpOnly secure flag by default

### DIFF
--- a/hawk/app/lib/hawk/secure_cookies.rb
+++ b/hawk/app/lib/hawk/secure_cookies.rb
@@ -17,8 +17,7 @@ module Hawk
           next if cookie.blank?
           next if cookie =~ /;\s*secure/i
 
-          cookie << '; Secure'
-          cookie << '; HttpOnly' if ENV['HAWK_COOKIE_HTTP_ONLY'] == 'true'
+          cookie << '; Secure ; HttpOnly'
         end
 
         headers['Set-Cookie'] = cookies.join(COOKIE_SEPARATOR)


### PR DESCRIPTION
The HttpOnly secure flag was set as default in 8db131080e, but then I changed my mind and made it parametrisable in 0008fdf613f7. However, after discussing with Johannes Segitz <jsegitz@suse.com> we decided to revert the 0008fdf613f7 and use the HttpOnly by default.