### PR TITLE
Fix auth

### DIFF
--- a/hawk/app/controllers/sessions_controller.rb
+++ b/hawk/app/controllers/sessions_controller.rb
@@ -43,7 +43,11 @@ class SessionsController < ApplicationController
         end
       else
         format.html do
-          flash.now[:alert] = @session.errors.first.last
+          if Gem.loaded_specs['rails'].version >= Gem::Version.new("6.1")
+            flash.now[:alert] = @session.errors.first.message
+          else
+            flash.now[:alert] = @session.errors.first.last
+          end
           render action: 'new'
         end
         format.json do

--- a/hawk/app/models/session.rb
+++ b/hawk/app/models/session.rb
@@ -39,7 +39,7 @@ class Session < Tableless
       end
 
       unless $?.exitstatus == 0
-        record.errors[:base] << _("Invalid username or password")
+        record.errors.add(:base, :blank, message: "Invalid username or password")
       end
     end
   end

--- a/tools/hawk_chkpwd.c
+++ b/tools/hawk_chkpwd.c
@@ -231,10 +231,17 @@ in_haclient_grp(const char *user)
 }
 
 static int
+pam_service_exists_in(const char *path, const char* name)
+{
+	char    full_path[128];
+	snprintf(full_path, sizeof(full_path), "%s%s", path, name);
+	return access(full_path, R_OK) == 0;
+}
+
+static int
 sane_pam_service(const char *name)
 {
 	const char *sp;
-	char	path[128];
 
 	if (strlen(name) > 32)
 		return 0;
@@ -243,8 +250,9 @@ sane_pam_service(const char *name)
 			return 0;
 	}
 
-	snprintf(path, sizeof(path), "/etc/pam.d/%s", name);
-	return access(path, R_OK) == 0;
+	return pam_service_exists_in("/etc/pam.d/", name)
+		|| pam_service_exists_in("/usr/bin/", name)
+		|| pam_service_exists_in("/usr/sbin/", name);
 }
 
 int


### PR DESCRIPTION
Update sanity check for passwd existance
Update validation for the newer versions of rails
    
The /etc/pam.d/passwd is optional in fact,
for example, there is none in the tumbleeweed.
So let's relax the condition: if there is no /etc/pam.d/passwd,
check if there is a passwd binary in /usr/bin of /usr/sbin
    
Starting with Rails6.1 there has changed the validation. Namelly,
the ActiveModel::Errors has changed it's structure.