### PR TITLE
Check rsc stonith is in maintenance by either of 2 keywords

### DIFF
--- a/e2e_test/hawk_test_ssh.py
+++ b/e2e_test/hawk_test_ssh.py
@@ -13,7 +13,7 @@ class HawkTestSSH:
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy)
         self.ssh.connect(hostname=hostname.lower(), username="root", password=secret)
 
-    def check_cluster_conf_ssh(self, command, mustmatch):
+    def check_cluster_conf_ssh(self, command, mustmatch, anycheck=False):
         _, out, err = self.ssh.exec_command(command)
         out, err = map(lambda f: f.read().decode().rstrip('\n'), (out, err))
         print(f"INFO: ssh command [{command}] got output [{out}] and error [{err}]")
@@ -21,16 +21,13 @@ class HawkTestSSH:
             print(f"ERROR: got an error over SSH: [{err}]")
             return False
         if isinstance(mustmatch, str):
-            if mustmatch:
-                if mustmatch in out:
-                    return True
-                return False
-            return out == mustmatch
-        if isinstance(mustmatch, list):
-            for exp in mustmatch:
-                if exp not in out:
-                    return False
-            return True
+            return mustmatch in out
+        if isinstance(mustmatch, list) and anycheck:
+            # Output has to match at least one element in the list
+            return any(_ in out for _ in mustmatch)
+        if isinstance(mustmatch, list) and not anycheck:
+            # Output has to match all elements in list
+            return all(_ in out for _ in mustmatch)
         raise ValueError("check_cluster_conf_ssh: mustmatch must be str or list")
 
     @staticmethod
@@ -39,12 +36,11 @@ class HawkTestSSH:
 
     def verify_stonith_in_maintenance(self, results):
         print("TEST: verify_stonith_in_maintenance")
-        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", "unmanaged") or \
-            self.check_cluster_conf_ssh("crm status | grep stonith-sbd", "maintenance"):
+        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", ["unmanaged", "maintenance"], True):
             print("INFO: stonith-sbd is unmanaged/maintenance")
             self.set_test_status(results, 'verify_stonith_in_maintenance', 'passed')
             return True
-        print("ERROR: stonith-sbd is not unmanaged but should be")
+        print("ERROR: stonith-sbd is not unmanaged nor in maintenance but should be")
         self.set_test_status(results, 'verify_stonith_in_maintenance', 'failed')
         return False
 


### PR DESCRIPTION
Newer versions of crmsh will report that a stonith resource is in maitenance by the `maintenance` keyword, while older versions use `unmanaged` instead.

This was addressed in commit b3998aaf6b23053772ad09eaa2e33964229c6fdb, but it is also causing the test script to connect twice to the cluster nodes over SSH to check first for `unmanaged` and then for `maintenance`.

Changes provided in this commit extend the function `check_cluster_conf_ssh` so it is able to match any or all of the keywords passed to it.

It does so by introducing a third parameter to `check_cluster_conf_ssh` so the function is able to match all provided keywords, or just one of them. The extra parameter informs the function whether it should do an "or" (set to false, i.e., "and", by default) and return True when any of the keywords is matched, or do an "and" and match all as it was doing before.

This commit also improves the log messages to reference both unmanaged and maintenance.