### PR TITLE
Fix: hb_report: indicate the 'crm report' failure

### DIFF
--- a/hawk/app/assets/javascripts/module/reports.js
+++ b/hawk/app/assets/javascripts/module/reports.js
@@ -28,7 +28,11 @@ $(function() {
             clearInterval(running_timeout);
             running_timeout = null;
           }
-          $.growl({ message: __("Report generation is complete.") }, { type: 'success' });
+          if (state.report_generated) {
+            $.growl({ message: __("Report generation is complete.") }, { type: 'success' });
+          } else {
+            $.growl({ message: __("Failed to create the report: " + state.msg ) }, { type: 'danger' });
+          }
           $('#reports #middle table.reports').bootstrapTable('refresh');
           build_tabs();
         }

--- a/hawk/app/controllers/reports_controller.rb
+++ b/hawk/app/controllers/reports_controller.rb
@@ -109,7 +109,8 @@ class ReportsController < ApplicationController
         @hb_report = HbReport.new
         running = @hb_report.running?
         t = running ? @hb_report.lasttime : nil
-        render json: { running: running, time: (t || ["", ""]) }
+        rc = @hb_report.report_generated?
+        render json: { running: running, time: (t || ["", ""]), report_generated: rc[:code], msg: rc[:msg] }
       end
     end
   end

--- a/hawk/app/lib/hb_report.rb
+++ b/hawk/app/lib/hb_report.rb
@@ -38,6 +38,23 @@ class HbReport
     Util.child_active(@pidfile)
   end
 
+  def report_generated?
+    return { code: false, msg: '' } if !File.exist?(@exitfile) || !File.exist?(@timefile)
+
+    rc = File.read(@exitfile).to_i
+    return { code: true, msg: '' } if rc==0
+
+    lt = lasttime
+    errfile = Rails.root.join('tmp', 'reports', "hawk-#{lt[0]}-#{lt[1]}.stderr").to_s
+    # .stderr file must exist even if there was no error
+    return { code: false, msg: '' } if !File.exist?(errfile)
+
+    err_text = File.read(errfile).split("\n")
+    err_msg = '<br>' + err_text[0]
+    err_msg += '<br>...<br>' + err_text[-1] if err_text.length() > 1
+    return { code: false, msg: err_msg }
+  end
+
   def cancel!
     pid = File.new(@pidfile).read.to_i
     return 0 if pid <= 0


### PR DESCRIPTION
Previously, even if the crm report had failed, the hawk would show the green status. In this change, we add reading ./tmp/pids/report.exit and ./tmp/reports/<report-file>.stderr We return the first line of the error message and the red status, if the execution has failed.