### PR TITLE
Dev: wizards: don't use root password

### DIFF
--- a/hawk/app/assets/javascripts/module/wizards.js
+++ b/hawk/app/assets/javascripts/module/wizards.js
@@ -101,9 +101,6 @@ $(function() {
     var errors = $.map(xhr.responseJSON, function(e) { return '<pre class="bg-danger">' + e + '</pre>'; }).join("");
     vform.find(".notifications").html(errors);
   });
-  vform.on("change", "#rootpw", function() {
-      vform.find(".submit").prop("disabled", false);
-  });
 
   $('.hljs').each(function(i, block) {
     hljs.highlightBlock(block);

--- a/hawk/app/controllers/wizards_controller.rb
+++ b/hawk/app/controllers/wizards_controller.rb
@@ -50,10 +50,10 @@ class WizardsController < ApplicationController
       @wizard.verify(pa)
       if @wizard.errors.length > 0
         render json: @wizard.errors.to_json, status: :unprocessable_entity
-      elsif current_cib.sim? && @wizard.need_rootpw
+      elsif current_cib.sim?
         render json: [_("Wizard cannot be applied when the simulator is active")], status: :unprocessable_entity
       else
-        @wizard.run(pa, params[:rootpw])
+        @wizard.run(pa)
         if @wizard.errors.length > 0
           render json: @wizard.errors.to_json, status: :unprocessable_entity
         else

--- a/hawk/app/lib/crm_script.rb
+++ b/hawk/app/lib/crm_script.rb
@@ -39,7 +39,7 @@ module CrmScript
   end
   module_function :cleanerr
 
-  def run(jsondata, rootpw)
+  def run(jsondata)
     user = current_user
     cmd = crmsh_escape(JSON.dump(jsondata))
     tmpf = Tempfile.new 'crmscript'

--- a/hawk/app/views/wizards/update.html.erb
+++ b/hawk/app/views/wizards/update.html.erb
@@ -61,22 +61,6 @@
                 <% end %>
               </ul>
             </div>
-            <% if @wizard.need_rootpw %>
-              <div class="alert alert-warning">
-                <p>
-                  <%= _("To apply the changes, Hawk requires root access, and password-less SSH access must be configured. See the Hawk documentation for more information.") %>
-                </p>
-              </div>
-              <div class="form-group">
-                <div class="col-sm-5 text-right">
-                  <%= label_tag(:rootpw, _("Root password")) %>
-                </div>
-                <div class="col-sm-7">
-                  <%= password_field_tag :rootpw, nil, class: "form-control", required: true %>
-                </div>
-                <div class="col-sm-5 help-block"></div>
-              </div>
-            <% end %>
           </fieldset>
           <%= main_form.button_group class: "wizard" do %>
             <%= link_to _("Cancel"), cib_wizards_path(cib_id: current_cib.id), class: "btn btn-default", data: { confirm: _("Do you really want to cancel the wizard setup?") } %>

--- a/hawk/config/initializers/filter.rb
+++ b/hawk/config/initializers/filter.rb
@@ -3,7 +3,6 @@
 
 Rails.application.config.tap do |config|
   config.filter_parameters += [
-    :password,
-    :rootpw
+    :password
   ]
 end


### PR DESCRIPTION
The root password that the user submits in the Wizards passwd-textbox eventually comes into the `CrmScript.run`, but it's simply ignored there. Here we delete the whole flow of the root password.