### PR TITLE
Fix: prepend all executable with /usr/sbin

### DIFF
--- a/hawk/app/lib/crm_script.rb
+++ b/hawk/app/lib/crm_script.rb
@@ -45,7 +45,7 @@ module CrmScript
     tmpf = Tempfile.new 'crmscript'
     tmpf.write("script json \"#{cmd}\"")
     tmpf.close
-    cmdline = ['crm', '-f', tmpf.path]
+    cmdline = ['/usr/sbin/crm', '-f', tmpf.path]
     old_home = Util.ensure_home_for(user)
     out, err, status = Util.capture3(*cmdline)
     tmpf.unlink

--- a/hawk/app/lib/hb_report.rb
+++ b/hawk/app/lib/hb_report.rb
@@ -115,7 +115,7 @@ class HbReport
       args.push("-Q") # Requires a version of crm report which supports this
       args.push("-S") unless all_nodes
       args.push(@path)
-      out, err, status = Util.capture3('crm', "report", *args)
+      out, err, status = Util.capture3('/usr/sbin/crm', "report", *args)
       f = File.new(@outfile, "w")
       f.write(out)
       f.close

--- a/hawk/app/lib/invoker.rb
+++ b/hawk/app/lib/invoker.rb
@@ -62,7 +62,7 @@ class Invoker
     begin
       f << cmd
       f.close
-      CrmEvents.instance.push "crm configure\n#{cmd}\n" unless @no_log
+      CrmEvents.instance.push "/usr/sbin/crm configure\n#{cmd}\n" unless @no_log
       result = crm '-F', 'configure', 'load', 'update', f.path
     ensure
       f.unlink
@@ -73,7 +73,7 @@ class Invoker
   # Invoke cibadmin with command line arguments.  Returns stdout as string,
   # Raises NotFoundError, SecurityError or RuntimeError on failure.
   def cibadmin(*cmd)
-    out, err, status = Util.run_as(current_user, current_pass, 'cibadmin', *cmd)
+    out, err, status = Util.run_as(current_user, current_pass, '/usr/sbin/cibadmin', *cmd)
     case status.exitstatus
     when 0
       return out
@@ -89,23 +89,23 @@ class Invoker
 
   # Invoke "cibadmin -p --replace"
   def cibadmin_replace(xml)
-    CrmEvents.instance.push "cibadmin -p --replace <<EOF\n#{xml}\nEOF" unless @no_log
+    CrmEvents.instance.push "/usr/sbin/cibadmin -p --replace <<EOF\n#{xml}\nEOF" unless @no_log
     cibadmin '-p', '--replace', stdin_data: xml
   end
 
   def cibadmin_replace_xpath(xpath, xml)
-    CrmEvents.instance.push "cibadmin -p --replace --xpath #{xpath} <<EOF\n#{xml}\nEOF" unless @no_log
+    CrmEvents.instance.push "/usr/sbin/cibadmin -p --replace --xpath #{xpath} <<EOF\n#{xml}\nEOF" unless @no_log
     cibadmin '-p', '--replace', '--xpath', xpath, stdin_data: xml
   end
 
   def cibadmin_modify(xml)
-    CrmEvents.instance.push "cibadmin -p -c --modify <<EOF\n#{xml}\nEOF" unless @no_log
+    CrmEvents.instance.push "/usr/sbin/cibadmin -p -c --modify <<EOF\n#{xml}\nEOF" unless @no_log
     cibadmin '-p', '-c', '--modify', stdin_data: xml
   end
 
   # Used by the simulator
   def crm_simulate(*cmd)
-    Util.run_as(current_user, current_pass, 'crm_simulate', *cmd)
+    Util.run_as(current_user, current_pass, '/usr/sbin/crm_simulate', *cmd)
   end
 
   private
@@ -132,7 +132,7 @@ class Invoker
     end
     cmd << { stdin_data: input }
 
-    out, err, status = Util.run_as(current_user, current_pass, 'crm', *cmd)
+    out, err, status = Util.run_as(current_user, current_pass, '/usr/sbin/crm', *cmd)
     [out, fudge_error(status.exitstatus, err), status.exitstatus]
   end
 

--- a/hawk/app/models/cib.rb
+++ b/hawk/app/models/cib.rb
@@ -511,7 +511,7 @@ class Cib
         init_offline_cluster id, user, use_file
         return
       end
-      out, err, status = Util.run_as(user, pass, 'cibadmin', '-Ql')
+      out, err, status = Util.run_as(user, pass, '/usr/sbin/cibadmin', '-Ql')
       case status.exitstatus
       when 0
         @xml = REXML::Document.new(out)
@@ -1125,7 +1125,7 @@ class Cib
         resource_node = REXML::XPath.first(elem, "ancestor::primitive")
         if booth_resource_id != resource_node.attributes["id"]
           booth_resource_id = resource_node.attributes["id"]
-          ip = Util.safe_x('crm_resource', '-r', "#{booth_resource_id}", '-g', 'ip').strip
+          ip = Util.safe_x('/usr/sbin/crm_resource', '-r', "#{booth_resource_id}", '-g', 'ip').strip
           next unless @booth[:sites].include?(ip)
 
           if !@booth[:me]

--- a/hawk/app/models/cluster.rb
+++ b/hawk/app/models/cluster.rb
@@ -102,7 +102,7 @@ class Cluster < Tableless
       fname = "#{Rails.root}/tmp/dashboard.js"
       File.open(fname, "w") { |f| f.write(JSON.pretty_generate(clusters)) }
       File.chmod(0660, fname)
-      out, err, rc = Util.capture3("crm", "cluster", "copy", fname)
+      out, err, rc = Util.capture3("/usr/sbin/crm", "cluster", "copy", fname)
       Rails.logger.debug "Copy: #{out} #{err} #{rc}"
       # always succeed here: we don't really care that much if the copy succeeded or not
       true

--- a/hawk/app/models/report.rb
+++ b/hawk/app/models/report.rb
@@ -85,7 +85,7 @@ class Report
   end
 
   def peinput_version(path)
-    nvpair = Util.safe_x("CIB_file=\"#{path}\"", 'cibadmin', '-Q', '--xpath', "/cib/configuration//crm_config//nvpair[@name='dc-version']", '2>/dev/null')
+    nvpair = Util.safe_x("CIB_file=\"#{path}\"", '/usr/sbin/cibadmin', '-Q', '--xpath', "/cib/configuration//crm_config//nvpair[@name='dc-version']", '2>/dev/null')
     m = nvpair.match(/value="([^"]+)"/)
     return nil unless m
     m[1]
@@ -144,7 +144,7 @@ class Report
     require "tempfile"
     tmpfile = Tempfile.new("hawk_dot")
     tmpfile.close
-    _out, err, status = Util.capture3('crm_simulate', '-x', tpath.to_s, format == :xml ? "-G" : "-D", tmpfile.path.to_s)
+    _out, err, status = Util.capture3('/usr/sbin/crm_simulate', '-x', tpath.to_s, format == :xml ? "-G" : "-D", tmpfile.path.to_s)
     rc = status.exitstatus
 
     ret = [false, err]

--- a/hawk/app/models/wizard.rb
+++ b/hawk/app/models/wizard.rb
@@ -72,7 +72,7 @@ class Wizard
   end
 
   def command_string
-    base = ["crm", "script", "run", @name]
+    base = ["/usr/sbin/crm", "script", "run", @name]
     @params.each do |k, v|
       if v.is_a? Hash
         v.each do |kk, vv|


### PR DESCRIPTION
Previously, all programs were executed as hacluster. In the 618cbc8 was enabled ACL, so that each program is executed under the current user. This however requires /usr/sbin to be in the $PATH. So here we prepend all executables with /usr/sbin.