### PR TITLE
Fix: enable colocation linking

### DIFF
--- a/hawk/app/models/colocation.rb
+++ b/hawk/app/models/colocation.rb
@@ -83,11 +83,11 @@ class Colocation < Constraint
         end
       else
         collapsed.each do |set2|
-          cmd.push " ( " unless set2[:sequential]
+          cmd.push " ( " if set2[:sequential] == false or set2[:sequential] == "false"
           set2[:resources].reverse_each do |r|
             cmd.push r + (set2[:action].blank? ? "" : ":#{set2[:action]}")
           end
-          cmd.push " )" unless set2[:sequential]
+          cmd.push " )" if set2[:sequential] == false or set2[:sequential] == "false"
         end
       end
 


### PR DESCRIPTION
Fix: enable colocation linking
    
The `shell_syntax` function was created 10 years ago and the json parsing has changed. The `set2[:sequential]` used to be boolean and now it's string.

TODO: tests.