### PR TITLE
Dev: replace 'cibadmin -!' with 'pacemakerd -F'

### DIFF
--- a/hawk/app/lib/util.rb
+++ b/hawk/app/lib/util.rb
@@ -326,7 +326,7 @@ module Util
     when :acl_support
       Rails.cache.fetch(:has_acl_support) {
         # full string is like "Pacemaker 2.1.5+20221208.a3f44794f-150500.6.5.8 (Build: 2.1.5+20221208.a3f44794f): agent-manpages cibsecrets ..."
-        spl = Util.safe_x('/usr/sbin/cibadmin', '-!').split(/\s+/)
+        spl = Util.safe_x('/usr/sbin/pacemakerd', '-F').split(/\s+/)
         return true if spl.include?("acls")
         
         # pacemaker > 2.1.0 always supports acls (though doesn't display the acls flag)

--- a/hawk/app/models/report.rb
+++ b/hawk/app/models/report.rb
@@ -50,7 +50,7 @@ class Report
     source = hb_report.path if File.directory?(hb_report.path)
 
     pcmk_version = nil
-    m = Util.safe_x('/usr/sbin/cibadmin', '-!').match(/^Pacemaker ([^ ]+) \(Build: ([^)]+)\)/)
+    m = Util.safe_x('/usr/sbin/pacemakerd', '-F').match(/^Pacemaker ([^ ]+) \(Build: ([^)]+)\)/)
     pcmk_version = "#{m[1]}-#{m[2]}" if m
 
     [].tap do |peinputs|


### PR DESCRIPTION
`cibadmin -!` is removed in ClusterLabs/pacemaker@e9b85f51