### PR TITLE
Fix: don't inflect/capitalize FENCING

### DIFF
--- a/hawk/config/initializers/inflections.rb
+++ b/hawk/config/initializers/inflections.rb
@@ -7,7 +7,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym "DC"
   inflect.acronym "SAP"
   inflect.acronym "NFS"
-  inflect.acronym "FENCING"
   inflect.acronym "IP"
   inflect.acronym "ID"
   inflect.acronym "LVS"


### PR DESCRIPTION
SLE 16 uses Rails8 and Zeitwerk ruby gem, which does a stricter inflection, so that fencing_controller.rb becomes FENCINGController