### PR TITLE
Test: build `hawk-node` run-time

### DIFF
--- a/.github/docker/hawk-node.Dockerfile
+++ b/.github/docker/hawk-node.Dockerfile
@@ -1,0 +1,29 @@
+FROM docker.io/opensuse/leap:15.6
+
+# install deps (hawk2 will pull all the gems, but uglifier)
+# libglue-devel is for stonith:external/ssh params hostlist
+RUN zypper -n refresh \
+ && zypper -n install --no-recommends \
+      systemd systemd-sysvinit openssh-server libglue-devel \
+      make gcc pam-devel hawk2 ruby2.5-rubygem-uglifier \
+ && zypper -n clean -a
+
+# allow root password login (specifically for the tests)
+RUN sed -i \
+      -e 's/^#\?PermitRootLogin .*/PermitRootLogin yes/' \
+      -e 's/^#\?PasswordAuthentication .*/PasswordAuthentication yes/' \
+      /etc/ssh/sshd_config
+
+RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
+ && cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+
+# unlock root and set password to "linux"
+RUN passwd -u root || true && echo -e "linux\nlinux" | passwd root
+
+# start sshd under systemd (`crm cluster init` will start it later anyway)
+RUN systemctl enable sshd
+
+# no need for the hawk itself, it should be copied in the git workflow
+RUN rm -rf /usr/share/hawk /etc/sysconfig/hawk
+
+CMD ["/usr/lib/systemd/systemd", "--system"]

--- a/.github/workflows/test-hawk.yaml
+++ b/.github/workflows/test-hawk.yaml
@@ -17,15 +17,17 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+      - name: Build hawk-node image (CI)
+        run: |
+          docker build -t hawk-node -f .github/docker/hawk-node.Dockerfile .
       - name: Start cluster nodes in containers
         run: |
-          docker run -d --privileged -h node1 --name node1 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} ghcr.io/aleksei-burlakov/hawk-node
-          docker run -d --privileged -h node2 --name node2 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} ghcr.io/aleksei-burlakov/hawk-node
+          docker run -d --privileged -h node1 --name node1 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} hawk-node
+          docker run -d --privileged -h node2 --name node2 --add-host node1:${IP_NODE1} --add-host node2:${IP_NODE2} hawk-node
       - name: Copy hawk to the nodes
         run: |
-          cd ..
-          docker cp hawk node1:/
-          docker cp hawk node2:/
+          docker cp "$GITHUB_WORKSPACE" node1:/
+          docker cp "$GITHUB_WORKSPACE" node2:/
       - name: Compile hawk in the nodes
         run: |
           docker exec -i node1 bash -c "cd hawk && make"
@@ -34,6 +36,12 @@ jobs:
         run: |
           docker exec -i node1 bash -c "cd hawk && make install && cp scripts/sysconfig.hawk /etc/sysconfig/hawk"
           docker exec -i node2 bash -c "cd hawk && make install && cp scripts/sysconfig.hawk /etc/sysconfig/hawk"
+      - name: Workaround to run hawk as root (ok for tests)
+        run: |
+          docker exec node1 sed -i '/^User=/d' /usr/lib/systemd/system/hawk-backend.service
+          docker exec node1 sed -i '/^Group=/d' /usr/lib/systemd/system/hawk-backend.service
+          docker exec node2 sed -i '/^User=/d' /usr/lib/systemd/system/hawk-backend.service
+          docker exec node2 sed -i '/^Group=/d' /usr/lib/systemd/system/hawk-backend.service
       - name: Initialize container on the node1
         run: docker exec node1 crm cluster init -u -n cluster1 -y
       - name: Join node2 to the cluster


### PR DESCRIPTION
Both Docker CI images — the one running Hawk and the hypervisor — were previously pre-built.
In this change, we build the node image at runtime instead. However, the hypervisor (hawk-examiner) is still pre-built.