### PR TITLE
Explicitly declare the geckodriver path to disable selenium automatic lookup with Leap16.0

### DIFF
--- a/e2e_test/hawk_test_driver.py
+++ b/e2e_test/hawk_test_driver.py
@@ -139,11 +139,14 @@ class HawkTestDriver:
             options.add_argument("--disable-dev-shm-usage")
             self.driver = webdriver.Chrome(options=options)
         else:
+            # Set geckodriver path to avoid Seleniums automatic lookup feature
+            # And raise error: Problem reading geckodriver versions
+            service = webdriver.FirefoxService(executable_path="/usr/local/bin/geckodriver")
             options = webdriver.FirefoxOptions()
             options.set_capability("acceptInsecureCerts", True)
             if self.headless:
                 options.add_argument("-headless")
-            self.driver = webdriver.Firefox(options=options)
+            self.driver = webdriver.Firefox(options=options,service=service)
 
         self.driver.maximize_window()
         return self.driver


### PR DESCRIPTION
Building container image with Leap16.0, selenium automatic lookup feature causes opening browser taking a long time with the followed message: 
`Problem reading geckodriver versions: error sending request for url (https://raw.githubusercontent.com/SeleniumHQ/selenium/trunk/common/geckodriver/geckodriversupport.json). Using latest geckodriver version`

For example: https://openqa.suse.de/tests/21531825#step/hawk_gui/62

Recorded in ticket https://jira.suse.com/browse/TEAM-11085

So explicitly declare the geckodriver path to disable selenium automatic lookup.

VRs:
https://openqa.suse.de/tests/21607684
https://openqa.suse.de/tests/21607671


