### PR TITLE
Add more timeout to mitigate ElementNotInteractableException

### DIFF
--- a/e2e_test/hawk_test_driver.py
+++ b/e2e_test/hawk_test_driver.py
@@ -699,12 +699,12 @@ class HawkTestDriver:
                                                                     Xpath.COMMIT_BTN_DANGER])
 
             # Second, click on Edit
-            time.sleep(2)
+            time.sleep(BIG_TIMEOUT)
             self.check_and_click_by_xpath(Error.HOT_PRIMITIVE_ERR, [Xpath.DROP_DOWN_FORMAT.format(resource_number_from_top),
                                                                      Xpath.HOT_PRIMITIVE_EDIT])
 
             # Third, rename the cool_primitive to hot_primitive
-            time.sleep(2) # wait the redirect finishes
+            time.sleep(BIG_TIMEOUT) # wait the redirect finishes
             # try to find '<a>Rename</a>' for 10 seconds (Ruby hawk),
             # if none --> look for '<button name="rename"> (Go hawk)
             rename_btn = self.find_element(By.LINK_TEXT, "Rename", 10) or self.find_element(By.NAME, "rename")


### PR DESCRIPTION
Please allow me to add more timeout to mitigate randomly selenium.common.exceptions.StaleElementReferenceException or  selenium.common.exceptions.ElementNotInteractableException.

Ticket: https://jira.suse.com/browse/TEAM-11084 

VR:
https://openqa.suse.de/tests/21633024
https://openqa.suse.de/tests/21633020
https://openqa.suse.de/tests/21633012
https://openqa.suse.de/tests/21633007
https://openqa.suse.de/tests/21633004