### PR TITLE
Fix: parsing `crm resources constraints <ID>` and :id for recent events menu

### DIFF
--- a/hawk/app/models/resource.rb
+++ b/hawk/app/models/resource.rb
@@ -147,16 +147,32 @@ class Resource < Record
   end
 
   def rsc_constraints
-    outp = Util.safe_x('/usr/sbin/crm_resource', '--resource', "#{id}", '-A', '2>/dev/null')
+    outp, err, status = Util.capture3('crm', 'resource', 'constraints', id)
     info = {}
+    section = nil
     outp.each_line do |l|
-      l.strip!
-      next if l.blank? || l.start_with?('* ')
-      m = l.match(/\s*: Node (\S+)\s+\(score=([^,]+), id=([^)]+)\)/)
-      if m && !info.key?(m[3])
-        info[m[3]] = { id: m[3], type: :location, score: m[2], other: m[1] }
-      else
-        m = l.match(/\s*(\S+)\s+\(score=([^,]+), id=([^)]+)\)/)
+      next if l.strip.blank?
+
+      if l.strip == "Locations:"
+        section = :location
+        next
+      elsif l.strip =~ /^Resources .+ is colocated with:$/
+        section = :colocation
+        next
+      elsif l !~ /^  / # new Top-Level-Section
+        section = nil
+        next
+      end
+
+      case section
+      when :location
+        m = l.match(/^  \* Node\s+(\S+)\s+\(score=([^,]+), id=([^,\)]+)/)
+        if m && !info.key?(m[3])
+          info[m[3]] = { id: m[3], type: :location, score: m[2], other: m[1] }
+        end
+
+      when :colocation
+        m = l.match(/^  \* (\S+)\s+\(score=([^,]+), id=([^,\)]+)/)
         if m && !info.key?(m[3])
           info[m[3]] = { id: m[3], type: :colocation, score: m[2], other: m[1] }
         end

--- a/hawk/config/routes.rb
+++ b/hawk/config/routes.rb
@@ -4,7 +4,7 @@
 Rails.application.routes.draw do
   root to: "pages#index"
 
-  regex_safe_id = /[^\^\/\[\]"<>#%{}|\\~`;?:@=&]+/
+  regex_safe_id = /[^\^\/\[\]"<>#%{}|\\~`;?:@=&]+?/
 
   resources :cib, only: [] do
     get "/", via: [:get, :post, :options], to: "cib#show", as: ""


### PR DESCRIPTION
- Use lazy, not greedy `regex_safe_id`, so that `:id` is correctly parsed
- `crm_resource` has changed its output format already in sle15.