### PR TITLE
Fix: parsing ambiguity in cib_ops_path format handling

### DIFF
--- a/hawk/app/views/nodes/events.html.erb
+++ b/hawk/app/views/nodes/events.html.erb
@@ -13,7 +13,7 @@
     </h3>
   </div>
   <div class="modal-body">
-    <table id="node-events" data-toggle="table" data-url="<%= cib_ops_path('*,'+@node.name, cib_id: current_cib, format: 'json') %>" data-sortable="true" data-sort-name="last_rc_change" data-sort-order="desc" data-row-style="eventsRowStyle">
+    <table id="node-events" data-toggle="table" data-url="<%= cib_ops_path('*,'+@node.name, cib_id: current_cib) %>?format=json" data-sortable="true" data-sort-name="last_rc_change" data-sort-order="desc" data-row-style="eventsRowStyle">
       <thead>
         <tr>
           <th data-field="rc" data-sortable="true" data-formatter="eventsRC">

--- a/hawk/app/views/resources/events.html.erb
+++ b/hawk/app/views/resources/events.html.erb
@@ -13,7 +13,7 @@
     </h3>
   </div>
   <div class="modal-body">
-    <table data-toggle="table" data-url='<%= cib_ops_path("#{@resource.id},*", cib_id: current_cib, format: "json") %>' data-sortable='true' data-sort-name='last_rc_change' data-sort-order='desc' data-row-style='eventsRowStyle' id="resource-events">
+    <table data-toggle="table" data-url='<%= cib_ops_path("#{@resource.id},*", cib_id: current_cib) %>?format=json' data-sortable='true' data-sort-name='last_rc_change' data-sort-order='desc' data-row-style='eventsRowStyle' id="resource-events">
       <thead>
         <tr>
           <th data-field="rc" data-sortable="true" data-formatter="eventsRC">

--- a/hawk/config/routes.rb
+++ b/hawk/config/routes.rb
@@ -4,13 +4,13 @@
 Rails.application.routes.draw do
   root to: "pages#index"
 
-  regex_safe_id = /[^\^\/\[\]"<>#%{}|\\~`;?:@=&]+?/
+  regex_safe_id = /[^\^\/\[\]"<>#%{}|\\~`;?:@=&]+/
 
   resources :cib, only: [] do
     get "/", via: [:get, :post, :options], to: "cib#show", as: ""
     match "/", via: [:options], to: "cib#show"
     match "/apply", as: :apply, to: 'cib#apply', via: [:get, :post]
-    get "/ops/:id", to: "cib#ops", as: :ops, constraints: {id: regex_safe_id }
+    get "/ops/:id", to: "cib#ops", as: :ops, constraints: { id: regex_safe_id }
 
     get "/fencing", to: "fencing#index"
     get "/fencing/edit", to: "fencing#edit"


### PR DESCRIPTION
The CibController#ops action expects the :id parameter in the form <resource>,<node>. When Rails appends .json to the URL, resource or node names containing dots become ambiguous and require special route constraints.

The CibController#ops function expects and :id in the form <resource>,<node> but there comes a concatenation of 3 values <resource>,<node><format>. Commit 32c14714 enables correct parsing 3 values, but it breaks the parsing in other controllers, when there is no <format> given. One could possibly distinguish the regular expressions for each of the cases, but let's better not glue too many values together, and just move the :format out, as a separate argument.