### PR TITLE
Dev: hide 'Add Resource' --> 'Multi-state' menu

### DIFF
--- a/hawk/app/views/resources/types.html.erb
+++ b/hawk/app/views/resources/types.html.erb
@@ -36,14 +36,6 @@
         <% end %>
       </li>
       <li class="btn btn-default btn-lg">
-        <%= link_to new_cib_master_path(cib_id: current_cib.id), data: { help_filter: ".multistate" } do %>
-          <div class="pull-right">
-            <%= icon_tag "plus-circle" %>
-          </div>
-          <%= icon_text "superscript", _("Multi-state") %>
-        <% end %>
-      </li>
-      <li class="btn btn-default btn-lg">
         <%= link_to new_cib_tag_path(cib_id: current_cib.id), data: { help_filter: ".tag" } do %>
           <div class="pull-right">
             <%= icon_tag "plus-circle" %>


### PR DESCRIPTION
* 'crm configure ms' is deprecated, the 'crm configure clone' command or 'Clone' menu should be used instead.
* The app/views/masters can potentially be removed.